### PR TITLE
Introduce PolicyWrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It consists of:
 ## Benefits over other libraries
 * `rezilience` allows you to use your own error type (the `E` in `ZIO[R, E, A]`) instead of forcing your effects to have `Exception` as error type
 * `rezilience` is lightweight, using only ZIO fibers and not spawning threads or blocking
-* It integrates smoothly with ZIO and ZIO libraries without prescribing any constraints.
+* It integrates smoothly with ZIO and ZIO libraries without prescribing any constraints and with good type inference.
 
 ## Installation
 
@@ -73,7 +73,7 @@ import CircuitBreaker._
 // We use Throwable as error type in this example 
 def myCallToExternalResource(someInput: String): ZIO[Any, Throwable, Int] = ???
 
-val circuitBreaker: ZManaged[Clock, Nothing, CircuitBreaker[Throwable]] = CircuitBreaker.make[Throwable](
+val circuitBreaker: ZManaged[Clock, Nothing, CircuitBreaker[Any]] = CircuitBreaker.make(
     trippingStrategy = TrippingStrategy.failureCount(maxFailures = 10),
     resetPolicy = Schedule.exponential(1.second),
     onStateChange = (s: State) => ZIO(println(s"State changed to ${s}")).ignore
@@ -176,10 +176,10 @@ import zio.clock._
 import zio.duration._
 import nl.vroste.rezilience._
 
-val policy: ZManaged[Clock, Nothing, PolicyWrap[Throwable]] = ZManaged.mapN(
+val policy: ZManaged[Clock, Nothing, PolicyWrap[Any]] = ZManaged.mapN(
   RateLimiter.make(1, 1.second),
   Bulkhead.make(10),
-  CircuitBreaker.withMaxFailures[Throwable](10)
+  CircuitBreaker.withMaxFailures(10)
 )(PolicyWrap.make(_, _, _))
 
 val myEffect: ZIO[Any, Exception, Unit] = ???

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ val circuitBreaker: ZManaged[Clock, Nothing, CircuitBreaker[Any]] = CircuitBreak
     )
 
 circuitBreaker.use { cb =>
-    val result: ZIO[Any, CircuitBreakerCallError[Throwable], Int] = cb.call(myCallToExternalResource("some input"))
+    val result: ZIO[Any, CircuitBreakerCallError[Throwable], Int] = cb(myCallToExternalResource("some input"))
 }
 ```
 
@@ -108,7 +108,7 @@ val bulkhead: UManaged[Bulkhead] = Bulkhead.make(maxInFlightCalls = 10, maxQueue
 
 bulkhead.use { bulkhead =>
   val result: ZIO[Any, BulkheadError[Throwable], Int] =
-        bulkhead.call(myCallToExternalResource("some input"))
+        bulkhead(myCallToExternalResource("some input"))
        
 }
 ```
@@ -132,7 +132,7 @@ val rateLimiter: UManaged[RateLimiter] = RateLimiter.make(max = 10, interval = 1
 
 rateLimiter.use { rateLimiter =>
   val result: ZIO[Any, Throwable, Int] =
-        rateLimiter.call(myCallToExternalResource("some input"))
+        rateLimiter(myCallToExternalResource("some input"))
        
 }
 ```
@@ -184,8 +184,8 @@ val policy: ZManaged[Clock, Nothing, PolicyWrap[Any]] = ZManaged.mapN(
 
 val myEffect: ZIO[Any, Exception, Unit] = ???
 
-policy.use { p => 
-  p.call(myEffect)
+policy.use { policy => 
+  policy(myEffect)
 }
 
 ```

--- a/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
+++ b/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
@@ -25,7 +25,7 @@ trait Bulkhead {
    * @return Effect that succeeds with the success of the given task or fails, when executed,
    *         with a WrappedError of the task's error, or when not executed, with a BulkheadRejection.
    */
-  def call[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A]
+  def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A]
 
   /**
    * Provides the number of in-flight and queued calls
@@ -82,7 +82,7 @@ object Bulkhead {
                              .fork
                              .toManaged_
     } yield new Bulkhead {
-      override def call[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A] =
+      override def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A] =
         for {
           result     <- Promise.make[E, A]
           enqueued   <- Promise.make[BulkheadRejection.type, Unit]

--- a/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -47,7 +47,7 @@ trait CircuitBreaker[-E] {
    * @return A ZIO that either succeeds with the success of the given f or fails with either a `CircuitBreakerOpen`
    *         or a `WrappedError` of the error of the given f
    */
-  def call[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A]
+  def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A]
 }
 
 object CircuitBreaker {
@@ -128,7 +128,7 @@ object CircuitBreaker {
         state.set(Closed) <*
         onStateChange(Closed).fork // Do not wait for user code
 
-      override def call[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A] =
+      override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A] =
         for {
           currentState <- state.get
           result       <- currentState match {

--- a/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -78,7 +78,7 @@ object CircuitBreaker {
   def withMaxFailures[E](
     maxFailures: Int,
     resetPolicy: Schedule[Clock, Any, Duration] = Schedule.exponential(1.second, 2.0),
-    isFailure: PartialFunction[E, Boolean] = PartialFunction.fromFunction[E, Boolean](_ => true),
+    isFailure: PartialFunction[E, Boolean] = isFailureAny[E],
     onStateChange: State => UIO[Unit] = _ => ZIO.unit
   ): ZManaged[Clock, Nothing, CircuitBreaker[E]] =
     make(TrippingStrategy.failureCount(maxFailures), resetPolicy, isFailure, onStateChange)
@@ -96,7 +96,7 @@ object CircuitBreaker {
   def make[E](
     trippingStrategy: ZManaged[Clock, Nothing, TrippingStrategy],
     resetPolicy: Schedule[Clock, Any, Any],
-    isFailure: PartialFunction[E, Boolean] = PartialFunction.fromFunction[E, Boolean](_ => true),
+    isFailure: PartialFunction[E, Boolean] = isFailureAny[E],
     onStateChange: State => UIO[Unit] = _ => ZIO.unit
   ): ZManaged[Clock, Nothing, CircuitBreaker[E]] =
     for {
@@ -169,4 +169,5 @@ object CircuitBreaker {
         } yield result
     }
 
+  private def isFailureAny[E]: PartialFunction[E, Boolean] = { case _ => true }
 }

--- a/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -1,10 +1,10 @@
 package nl.vroste.rezilience
 
-import nl.vroste.rezilience.CircuitBreaker.{ CircuitBreakerCallError, WrappedError }
-import zio.clock.Clock
-import zio.stream.ZStream
+import nl.vroste.rezilience.CircuitBreaker.CircuitBreakerCallError
 import zio._
+import zio.clock.Clock
 import zio.duration._
+import zio.stream.ZStream
 
 /**
  * CircuitBreaker protects external resources against overload under failure
@@ -38,7 +38,7 @@ import zio.duration._
  * 2) Failure rate. When the fraction of failed calls in some sample period exceeds
  *    a threshold (between 0 and 1), the circuit breaker is tripped.
  */
-trait CircuitBreaker {
+trait CircuitBreaker[E] {
 
   /**
    * Execute a given effect with the circuit breaker
@@ -47,32 +47,7 @@ trait CircuitBreaker {
    * @return A ZIO that either succeeds with the success of the given f or fails with either a `CircuitBreakerOpen`
    *         or a `WrappedError` of the error of the given f
    */
-  def withCircuitBreaker[R, E, A](f: ZIO[R, E, A]): ZIO[R with Clock, CircuitBreakerCallError[E], A]
-
-  /**
-   * Execute the given effect with the circuit breaker
-   *
-   * Only failures that match according to `isFailure` are treated as failures by the circuit breaker. Other failures
-   * are passed on, circumventing the circuit breaker's failure counter.
-   *
-   * @param f
-   * @param isFailure
-   * @tparam R
-   * @tparam E
-   * @tparam A
-   * @return
-   */
-  def withCircuitBreaker[R, E, A](
-    f: ZIO[R, E, A],
-    isFailure: PartialFunction[E, Any]
-  ): ZIO[R with Clock, CircuitBreakerCallError[E], A] =
-    withCircuitBreaker {
-      f.either.flatMap {
-        case Left(e) if isFailure.isDefinedAt(e) => ZIO.fail(e)
-        case Left(e)                             => ZIO.left(WrappedError(e))
-        case Right(e)                            => ZIO.right(e)
-      }
-    }.absolve
+  def call[R, A](f: ZIO[R, E, A]): ZIO[R, CircuitBreakerCallError[E], A]
 }
 
 object CircuitBreaker {
@@ -95,29 +70,35 @@ object CircuitBreaker {
    *
    * @param maxFailures Maximum number of failures before tripping the circuit breaker
    * @param resetPolicy Reset schedule after too many failures. Typically an exponential backoff strategy is used.
+   * @param isFailure Only failures that match according to `isFailure` are treated as failures by the circuit breaker.
+   *                  Other failures are passed on, circumventing the circuit breaker's failure counter.
    * @param onStateChange Observer for circuit breaker state changes
    * @return The CircuitBreaker as a managed resource
    */
-  def withMaxFailures(
+  def withMaxFailures[E](
     maxFailures: Int,
     resetPolicy: Schedule[Clock, Any, Duration] = Schedule.exponential(1.second, 2.0),
+    isFailure: PartialFunction[E, Any] = PartialFunction.fromFunction[E, Any](_ => true),
     onStateChange: State => UIO[Unit] = _ => ZIO.unit
-  ): ZManaged[Clock, Nothing, CircuitBreaker] =
-    make(TrippingStrategy.failureCount(maxFailures), resetPolicy, onStateChange)
+  ): ZManaged[Clock, Nothing, CircuitBreaker[E]] =
+    make(TrippingStrategy.failureCount(maxFailures), resetPolicy, isFailure, onStateChange)
 
   /**
    * Create a CircuitBreaker with the given tripping strategy
    *
    * @param trippingStrategy Determines under which conditions the CircuitBraker trips
    * @param resetPolicy Reset schedule after too many failures. Typically an exponential backoff strategy is used.
+   * @param isFailure Only failures that match according to `isFailure` are treated as failures by the circuit breaker.
+   *                  Other failures are passed on, circumventing the circuit breaker's failure counter.
    * @param onStateChange Observer for circuit breaker state changes
    * @return
    */
-  def make[R1](
-    trippingStrategy: ZManaged[R1, Nothing, TrippingStrategy],
+  def make[E](
+    trippingStrategy: ZManaged[Clock, Nothing, TrippingStrategy],
     resetPolicy: Schedule[Clock, Any, Any],
+    isFailure: PartialFunction[E, Any] = PartialFunction.fromFunction[E, Any](_ => true),
     onStateChange: State => UIO[Unit] = _ => ZIO.unit
-  ): ZManaged[R1 with Clock, Nothing, CircuitBreaker] =
+  ): ZManaged[Clock, Nothing, CircuitBreaker[E]] =
     for {
       strategy       <- trippingStrategy
       state          <- Ref.make[State](Closed).toManaged_
@@ -136,7 +117,7 @@ object CircuitBreaker {
                           }
                           .runDrain
                           .forkManaged
-    } yield new CircuitBreaker {
+    } yield new CircuitBreaker[E] {
 
       val changeToOpen = state.set(Open) *>
         resetRequests.offer(()) <*
@@ -147,7 +128,7 @@ object CircuitBreaker {
         state.set(Closed) <*
         onStateChange(Closed).fork // Do not wait for user code
 
-      override def withCircuitBreaker[R, E, A](f: ZIO[R, E, A]): ZIO[R with Clock, CircuitBreakerCallError[E], A] =
+      override def call[R, A](f: ZIO[R, E, A]): ZIO[R, CircuitBreakerCallError[E], A] =
         for {
           currentState <- state.get
           result       <- currentState match {
@@ -160,8 +141,15 @@ object CircuitBreaker {
                                     changeToOpen
                                   }
 
-                              f.tapBoth(_ => onFail, _ => strategy.onSuccess)
+                              f.either.flatMap {
+                                case Left(e) if isFailure.isDefinedAt(e) => ZIO.fail(e)
+                                case Left(e)                             => ZIO.left(WrappedError(e))
+                                case Right(e)                            => ZIO.right(e)
+
+                              }
+                                .tapBoth(_ => onFail, _ => strategy.onSuccess)
                                 .mapError(WrappedError(_))
+                                .absolve
                             case Open     =>
                               ZIO.fail(CircuitBreakerOpen)
                             case HalfOpen =>

--- a/src/main/scala/nl/vroste/rezilience/PolicyWrap.scala
+++ b/src/main/scala/nl/vroste/rezilience/PolicyWrap.scala
@@ -1,0 +1,79 @@
+package nl.vroste.rezilience
+import nl.vroste.rezilience.Bulkhead.{ BulkheadError, Metrics }
+import nl.vroste.rezilience.CircuitBreaker.CircuitBreakerCallError
+import nl.vroste.rezilience.PolicyWrap.PolicyError
+import zio.{ Schedule, UIO, ZIO }
+import zio.clock.Clock
+
+/**
+ * Represents a combination of rezilience policies
+ */
+trait PolicyWrap[E] {
+  def call[R, A](task: ZIO[R, E, A]): ZIO[R with Clock, PolicyError[E], A]
+}
+
+object PolicyWrap {
+  sealed trait PolicyError[+E]
+
+  case class WrappedError[E](e: E) extends PolicyError[E]
+  case object BulkheadRejection    extends PolicyError[Nothing]
+  case object CircuitBreakerOpen   extends PolicyError[Nothing]
+
+  /**
+   * Creates a rezilience policy that wraps calls with a circuit breaker, followed by a bulkhead,
+   * followed by a rate limiter, followed by a retry policy.
+   *
+   * i.e. retry(withRateLimiter(withBulkhead(withCircuitBreaker(effect)))
+   *
+   * Each of these wraps are optional by the default values for these three policies being noop versions
+   */
+  def make[E](
+    rateLimiter: RateLimiter = noopRateLimiter,
+    bulkhead: Bulkhead = noopBulkhead,
+    circuitBreaker: CircuitBreaker[E] = noopCircuitBreaker,
+    retrySchedule: Schedule[Any, PolicyError[E], Any] = Schedule.stop
+  ): PolicyWrap[E] = new PolicyWrap[E] {
+    override def call[R, A](task: ZIO[R, E, A]): ZIO[R with Clock, PolicyError[E], A] =
+      rateLimiter.call {
+        bulkhead.call {
+          circuitBreaker
+            .call(task)
+            .mapError(circuitBreakerErrorToPolicyError)
+        }
+          .mapError(bulkheadErrorToPolicyError)
+          .mapError(flattenWrappedError)
+      }.retry(retrySchedule)
+  }
+
+  def noopCircuitBreaker[E]: CircuitBreaker[E] = new CircuitBreaker[E] {
+    override def call[R, A](f: ZIO[R, E, A]): ZIO[R, CircuitBreakerCallError[E], A] =
+      f.mapError(CircuitBreaker.WrappedError(_))
+  }
+
+  val noopBulkhead: Bulkhead = new Bulkhead {
+    override def call[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A] =
+      task.mapError(Bulkhead.WrappedError(_))
+
+    override def metrics: UIO[Metrics] = UIO.succeed(Metrics.apply(0, 0))
+  }
+
+  val noopRateLimiter: RateLimiter = new RateLimiter {
+    override def call[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] = task
+  }
+
+  def circuitBreakerErrorToPolicyError[E]: CircuitBreakerCallError[E] => PolicyError[E] = {
+    case CircuitBreaker.CircuitBreakerOpen => CircuitBreakerOpen
+    case CircuitBreaker.WrappedError(e)    => WrappedError(e)
+  }
+
+  def bulkheadErrorToPolicyError[E]: BulkheadError[E] => PolicyError[E] = {
+    case Bulkhead.BulkheadRejection => BulkheadRejection
+    case Bulkhead.WrappedError(e)   => WrappedError(e)
+  }
+
+  def flattenWrappedError[E]: PolicyError[PolicyError[E]] => PolicyError[E] = {
+    case WrappedError(e)    => e
+    case CircuitBreakerOpen => CircuitBreakerOpen
+    case BulkheadRejection  => BulkheadRejection
+  }
+}

--- a/src/main/scala/nl/vroste/rezilience/PolicyWrap.scala
+++ b/src/main/scala/nl/vroste/rezilience/PolicyWrap.scala
@@ -8,8 +8,8 @@ import zio.clock.Clock
 /**
  * Represents a combination of rezilience policies
  */
-trait PolicyWrap[E] {
-  def call[R, A](task: ZIO[R, E, A]): ZIO[R with Clock, PolicyError[E], A]
+trait PolicyWrap[-E] {
+  def call[R, E1 <: E, A](task: ZIO[R, E1, A]): ZIO[R with Clock, PolicyError[E1], A]
 }
 
 object PolicyWrap {
@@ -33,7 +33,7 @@ object PolicyWrap {
     circuitBreaker: CircuitBreaker[E] = noopCircuitBreaker,
     retrySchedule: Schedule[Any, PolicyError[E], Any] = Schedule.stop
   ): PolicyWrap[E] = new PolicyWrap[E] {
-    override def call[R, A](task: ZIO[R, E, A]): ZIO[R with Clock, PolicyError[E], A] =
+    override def call[R, E1 <: E, A](task: ZIO[R, E1, A]): ZIO[R with Clock, PolicyError[E1], A] =
       rateLimiter.call {
         bulkhead.call {
           circuitBreaker
@@ -46,7 +46,7 @@ object PolicyWrap {
   }
 
   def noopCircuitBreaker[E]: CircuitBreaker[E] = new CircuitBreaker[E] {
-    override def call[R, A](f: ZIO[R, E, A]): ZIO[R, CircuitBreakerCallError[E], A] =
+    override def call[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A] =
       f.mapError(CircuitBreaker.WrappedError(_))
   }
 

--- a/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -1,5 +1,5 @@
 package nl.vroste.rezilience
-import zio.duration.Duration
+import zio.duration.{ durationInt, Duration }
 import zio.stream.ZStream
 import zio._
 import zio.clock.Clock
@@ -37,7 +37,7 @@ object RateLimiter {
    * @param interval Interval duration
    * @return RateLimiter
    */
-  def make(max: Long, interval: Duration): ZManaged[Clock, Nothing, RateLimiter] = for {
+  def make(max: Long, interval: Duration = 1.second): ZManaged[Clock, Nothing, RateLimiter] = for {
     q <- Queue.unbounded[UIO[Any]].toManaged_
     _ <- ZStream
            .fromQueue(q)

--- a/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -21,7 +21,7 @@ trait RateLimiter {
    * @param task Task to execute. When the rate limit is exceeded, the call will be postponed. The environment of the
    *             task i
    */
-  def call[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A]
+  def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A]
 }
 
 object RateLimiter {
@@ -46,7 +46,7 @@ object RateLimiter {
            .runDrain
            .forkManaged
   } yield new RateLimiter {
-    override def call[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] = for {
+    override def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] = for {
       p      <- Promise.make[E, A]
       env    <- ZIO.environment[R]
       effect  = task.foldM(p.fail, p.succeed).provide(env)

--- a/src/test/scala/nl/vroste/rezilience/FailureRateTrippingStrategySpec.scala
+++ b/src/test/scala/nl/vroste/rezilience/FailureRateTrippingStrategySpec.scala
@@ -63,11 +63,11 @@ object FailureRateTrippingStrategySpec extends DefaultRunnableSpec {
             for {
               // Make a succeeding and a failing call 4 times every 100 ms
               _ <- {
-                cb.call(ZIO.unit) *> cb.call(ZIO.fail("Oh Oh")).either
+                cb(ZIO.unit) *> cb(ZIO.fail("Oh Oh")).either
               }.repeat(Schedule.spaced(150.millis) && Schedule.recurs(3))
               // Next call should fail
               _ <- ZIO.sleep(50.millis)
-              r <- cb.call(UIO(println("Succeeding call that should fail fast"))).run
+              r <- cb(UIO(println("Succeeding call that should fail fast"))).run
             } yield assert(r)(fails(equalTo(CircuitBreakerOpen)))
           }
       }.provideSomeLayer(zio.clock.Clock.live),
@@ -87,7 +87,7 @@ object FailureRateTrippingStrategySpec extends DefaultRunnableSpec {
             for {
               // Make a succeeding and a failing call 4 times every 100 ms
               _ <- {
-                cb.call(ZIO.unit) *> cb.call(ZIO.fail("Oh Oh")).either
+                cb(ZIO.unit) *> cb(ZIO.fail("Oh Oh")).either
               }.repeat(Schedule.spaced(150.millis) && Schedule.recurs(10))
             } yield assertCompletes
           }
@@ -105,7 +105,7 @@ object FailureRateTrippingStrategySpec extends DefaultRunnableSpec {
                             .make[String](strategy, Schedule.fixed(1.seconds), onStateChange = stateChanges.offer(_).ignore)
         } yield (stateChanges, cb)).use { case (stateChanges, cb) =>
           def expectState(s: State)                = stateChanges.take.filterOrDieMessage(_ == s)(s"Expected state ${s}")
-          def makeCall[R, A](f: ZIO[R, String, A]) = cb.call(f)
+          def makeCall[R, A](f: ZIO[R, String, A]) = cb(f)
 
           for {
             // Make a succeeding and a failing call 4 times every 100 ms

--- a/src/test/scala/nl/vroste/rezilience/FailureRateTrippingStrategySpec.scala
+++ b/src/test/scala/nl/vroste/rezilience/FailureRateTrippingStrategySpec.scala
@@ -81,7 +81,7 @@ object FailureRateTrippingStrategySpec extends DefaultRunnableSpec {
           .make[String](
             strategy,
             Schedule.fixed(5.seconds),
-            state => ZIO.effectTotal(println(s"CB state changed to ${state}"))
+            onStateChange = state => ZIO.effectTotal(println(s"CB state changed to ${state}"))
           )
           .use { cb =>
             for {

--- a/src/test/scala/nl/vroste/rezilience/FailureRateTrippingStrategySpec.scala
+++ b/src/test/scala/nl/vroste/rezilience/FailureRateTrippingStrategySpec.scala
@@ -3,11 +3,10 @@ package nl.vroste.rezilience
 import zio.duration._
 import zio.test.Assertion._
 import zio.test._
-import zio.{ Schedule, ZIO }
+import zio.{ Queue, Schedule, UIO, ZIO }
 import zio.random.Random
 import zio.test.environment.TestClock
 import nl.vroste.rezilience.CircuitBreaker.CircuitBreakerOpen
-import zio.Queue
 import nl.vroste.rezilience.CircuitBreaker.State
 
 case class PrintFriendlyDuration(duration: Duration) extends AnyVal {
@@ -59,16 +58,16 @@ object FailureRateTrippingStrategySpec extends DefaultRunnableSpec {
 
         val strategy = TrippingStrategy.failureRate(rate, sampleDuration, minThroughput, nrSampleBuckets = 10)
         CircuitBreaker
-          .make(strategy, resetPolicy = Schedule.fixed(5.seconds))
+          .make[String](strategy, resetPolicy = Schedule.fixed(5.seconds))
           .use { cb =>
             for {
               // Make a succeeding and a failing call 4 times every 100 ms
               _ <- {
-                cb.withCircuitBreaker(ZIO.unit) *> cb.withCircuitBreaker(ZIO.fail("Oh Oh")).either
+                cb.call(ZIO.unit) *> cb.call(ZIO.fail("Oh Oh")).either
               }.repeat(Schedule.spaced(150.millis) && Schedule.recurs(3))
               // Next call should fail
               _ <- ZIO.sleep(50.millis)
-              r <- cb.withCircuitBreaker(ZIO(println("Succeeding call that should fail fast"))).run
+              r <- cb.call(UIO(println("Succeeding call that should fail fast"))).run
             } yield assert(r)(fails(equalTo(CircuitBreakerOpen)))
           }
       }.provideSomeLayer(zio.clock.Clock.live),
@@ -79,12 +78,16 @@ object FailureRateTrippingStrategySpec extends DefaultRunnableSpec {
 
         val strategy = TrippingStrategy.failureRate(rate, sampleDuration, minThroughput, nrSampleBuckets = 10)
         CircuitBreaker
-          .make(strategy, Schedule.fixed(5.seconds), state => ZIO.effectTotal(println(s"CB state changed to ${state}")))
+          .make[String](
+            strategy,
+            Schedule.fixed(5.seconds),
+            state => ZIO.effectTotal(println(s"CB state changed to ${state}"))
+          )
           .use { cb =>
             for {
               // Make a succeeding and a failing call 4 times every 100 ms
               _ <- {
-                cb.withCircuitBreaker(ZIO.unit) *> cb.withCircuitBreaker(ZIO.fail("Oh Oh")).either
+                cb.call(ZIO.unit) *> cb.call(ZIO.fail("Oh Oh")).either
               }.repeat(Schedule.spaced(150.millis) && Schedule.recurs(10))
             } yield assertCompletes
           }
@@ -99,10 +102,10 @@ object FailureRateTrippingStrategySpec extends DefaultRunnableSpec {
         (for {
           stateChanges <- Queue.unbounded[State].toManaged_
           cb           <- CircuitBreaker
-                            .make(strategy, Schedule.fixed(1.seconds), stateChanges.offer(_).ignore)
+                            .make[String](strategy, Schedule.fixed(1.seconds), onStateChange = stateChanges.offer(_).ignore)
         } yield (stateChanges, cb)).use { case (stateChanges, cb) =>
-          def expectState(s: State)              = stateChanges.take.filterOrDieMessage(_ == s)(s"Expected state ${s}")
-          def makeCall[R, E, A](f: ZIO[R, E, A]) = cb.withCircuitBreaker(f)
+          def expectState(s: State)                = stateChanges.take.filterOrDieMessage(_ == s)(s"Expected state ${s}")
+          def makeCall[R, A](f: ZIO[R, String, A]) = cb.call(f)
 
           for {
             // Make a succeeding and a failing call 4 times every 100 ms

--- a/src/test/scala/nl/vroste/rezilience/PolicyWrapSpec.scala
+++ b/src/test/scala/nl/vroste/rezilience/PolicyWrapSpec.scala
@@ -1,0 +1,98 @@
+package nl.vroste.rezilience
+import nl.vroste.rezilience.PolicyWrap.WrappedError
+import zio.duration.durationInt
+import zio.{ Fiber, Promise, Schedule, ZIO, ZManaged }
+import zio.test.DefaultRunnableSpec
+import zio.test._
+import zio.test.Assertion._
+import zio.test.environment.TestClock
+
+object PolicyWrapSpec extends DefaultRunnableSpec {
+  sealed trait Error
+  case object MyCallError     extends Error
+  case object MyNotFatalError extends Error
+
+  override def spec = suite("PolicyWrap")(
+    testM("succeeds the first call immediately regardless of the policies") {
+      val policy =
+        ZManaged.mapN(RateLimiter.make(1), Bulkhead.make(100), CircuitBreaker.withMaxFailures[Error](10))(
+          PolicyWrap.make(_, _, _)
+        )
+
+      policy.use { policy =>
+        for {
+          result <- policy.call(ZIO.succeed(123))
+        } yield assert(result)(equalTo(123))
+
+      }
+    },
+    testM("fails the first call when retry is disabled") {
+      val policy =
+        ZManaged.mapN(RateLimiter.make(1), Bulkhead.make(100), CircuitBreaker.withMaxFailures[Error](10))(
+          PolicyWrap.make(_, _, _)
+        )
+
+      policy.use { policy =>
+        for {
+          result <- policy.call(ZIO.fail(MyCallError)).flip
+        } yield assert(result)(equalTo(WrappedError(MyCallError)))
+      }
+    },
+    testM("fail with a circuit breaker error after too many failed calls") {
+      val policy =
+        ZManaged.mapN(
+          RateLimiter.make(2),
+          Bulkhead.make(100),
+          CircuitBreaker.withMaxFailures[Error](1)
+        )(PolicyWrap.make(_, _, _))
+
+      policy.use { policy =>
+        for {
+          _      <- policy.call(ZIO.fail(MyCallError)).flip
+          result <- policy.call(ZIO.fail(MyCallError)).flip
+        } yield assert(result)(equalTo(PolicyWrap.CircuitBreakerOpen))
+      }
+    },
+    testM("fail with a bulkhead error after too many calls in progress") {
+      val policy =
+        ZManaged.mapN(
+          RateLimiter.make(10),
+          Bulkhead.make(1, maxQueueing = 1),
+          CircuitBreaker.withMaxFailures[Error](1)
+        )(PolicyWrap.make(_, _, _))
+
+      policy.use { policy =>
+        for {
+          latch  <- Promise.make[Nothing, Unit]
+          latch2 <- Promise.make[Nothing, Unit]
+          _      <- policy.call(latch.succeed(()) *> latch2.await).fork
+          _      <- policy.call(latch.succeed(()) *> latch2.await).fork
+          _      <- latch.await
+          result <- policy.call(ZIO.succeed(123)).flip
+          _      <- latch2.succeed(())
+        } yield assert(result)(equalTo(PolicyWrap.BulkheadRejection))
+      }
+    },
+    testM("rate limit") {
+      val policy =
+        ZManaged.mapN(
+          RateLimiter.make(2),
+          Bulkhead.make(10),
+          CircuitBreaker.withMaxFailures[Error](1)
+        )(PolicyWrap.make(_, _, _))
+
+      policy.use { policy =>
+        for {
+          _             <- policy.call(ZIO.unit)
+          _             <- policy.call(ZIO.unit)
+          fib           <- policy.call(ZIO.succeed(123)).fork
+          _             <- TestClock.adjust(0.seconds)
+          initialStatus <- fib.status
+          _             <- TestClock.adjust(1.seconds)
+          _             <- fib.join
+        } yield assert(initialStatus)(Assertion.isSubtype[Fiber.Status.Suspended](anything))
+      }
+    }
+  )
+
+}

--- a/src/test/scala/nl/vroste/rezilience/RateLimiterSpec.scala
+++ b/src/test/scala/nl/vroste/rezilience/RateLimiterSpec.scala
@@ -11,29 +11,29 @@ object RateLimiterSpec extends DefaultRunnableSpec {
       RateLimiter.make(10, 1.second).use { rl =>
         for {
           now   <- clock.instant
-          times <- ZIO.foreach((1 to 10).toList)(_ => rl.call(clock.instant))
+          times <- ZIO.foreach((1 to 10).toList)(_ => rl(clock.instant))
         } yield assert(times)(forall(equalTo(now)))
       }
     },
     testM("succeed with the result of the call") {
       RateLimiter.make(10, 1.second).use { rl =>
         for {
-          result <- rl.call(ZIO.succeed(3))
+          result <- rl(ZIO.succeed(3))
         } yield assert(result)(equalTo(3))
       }
     },
     testM("fail with the result of a failed call") {
       RateLimiter.make(10, 1.second).use { rl =>
         for {
-          result <- rl.call(ZIO.fail(None)).either
+          result <- rl(ZIO.fail(None)).either
         } yield assert(result)(isLeft(isNone))
       }
     },
     testM("continue after a failed call") {
       RateLimiter.make(10, 1.second).use { rl =>
         for {
-          _ <- rl.call(ZIO.fail(None)).either
-          _ <- rl.call(ZIO.succeed(3))
+          _ <- rl(ZIO.fail(None)).either
+          _ <- rl(ZIO.succeed(3))
         } yield assertCompletes
       }
     },
@@ -41,7 +41,7 @@ object RateLimiterSpec extends DefaultRunnableSpec {
       RateLimiter.make(10, 1.second).use { rl =>
         for {
           now   <- clock.instant
-          fib   <- ZIO.foreach((1 to 20).toList)(_ => rl.call(clock.instant)).fork
+          fib   <- ZIO.foreach((1 to 20).toList)(_ => rl(clock.instant)).fork
           _     <- TestClock.adjust(1.second)
           later <- clock.instant
           times <- fib.join


### PR DESCRIPTION
* Add error type parameter to CircuitBreaker
* Move 'isFailure' to CircuitBreaker.make
* Update Readme
* Improve type inference
* Rename `call` to `apply` for nicer usage syntax