### PR TITLE
Improve policy composition + handling policy errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,4 +80,4 @@ lazy val docs = project
 //    micrositeAnalyticsToken := "UA-56320875-2",
 //    includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.txt" | "*.xml" | "*.svg",
   )
-  .dependsOn(rezilience.jvm)
+//  .dependsOn(rezilience.jvm)

--- a/build.sbt
+++ b/build.sbt
@@ -80,4 +80,4 @@ lazy val docs = project
 //    micrositeAnalyticsToken := "UA-56320875-2",
 //    includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.txt" | "*.xml" | "*.svg",
   )
-//  .dependsOn(rezilience.jvm)
+  .dependsOn(rezilience.jvm)

--- a/docs/docs/docs/combining.md
+++ b/docs/docs/docs/combining.md
@@ -6,18 +6,41 @@ permalink: docs/combining_policies/
 
 # Combining policies
 
-The above policies can be combined into one `Policy` to combine several resilience strategies.
+`rezilience` policies can be composed into one to apply several resilience strategies as one. 
 
-Many variations of policy combinations are possible, but one example is to have a `Retry` around a `RateLimiter`.
+A composed policy has a wider range of possible errors than an individual policy. This is made explicit by having to convert each policy to an instance of `Policy` by calling `.toPolicy`. Such a `Policy` has a slightly different signature for the `apply` method in the error type:
 
-To compose policies, convert them into a `Policy` instance using `toPolicy` and use `.compose` to wrap it in another policy. For example:
+```scala
+def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, PolicyError[E1], A]
+```
+
+A policy can be composed with another one using its `compose` method, which wraps another policy around it. Below is an example of wrapping a `Retry` around a `RateLimiter` around a `Bulkhead`. The for-comprehension is needed because policies are created as `ZManaged`s.
 
 ```scala
 val policy: ZManaged[Clock, Nothing, Policy[Any]] = for {
-rateLimiter <- RateLimiter.make(1, 2.seconds)
-bulkhead    <- Bulkhead.make(2)
-retry       <- Retry.make(Schedule.recurs(3))
+  rateLimiter <- RateLimiter.make(1, 2.seconds)
+  bulkhead    <- Bulkhead.make(2)
+  retry       <- Retry.make(Schedule.recurs(3))
 } yield bulkhead.toPolicy compose rateLimiter.toPolicy compose retry.toPolicy
 ```
 
-Because of type-safety, you sometimes need to transform your individual policies to work with the errors produced by inner policies. Take for example, a Retry around a `CircuitBreaker` that you want to call with. If you want to retry on any error, a `Retry[Any]` is fine. But if you only want to use a Retry on ZIOs with error type `E` and your Retry policy defines that it only wants to retry a subset of those errors, eg `E1 <: E`, you will need to adapt it to decide what to do with the `CircuitBreakerError[E]` that is the output error type of the `CircuitBreaker`. 
+Composing policies requires some special care in handling policy errors, behavior-wise and type-wise. Take for example a retry around a circuit breaker. 
+
+1. Behavior: what is the desired retry behavior when a circuit breaker error is encountered? Should the call be retried or the error passed through to the caller? 
+
+2. Types: because a `Retry` is created with a `Schedule` that expects a certain type `E` of errors as input, a `Retry[E]` cannot be applied on ZIO[R, CircuitBreaker[E], A] effects.
+
+For these cases, the `Retry` and `CircuitBreaker` policies have a `widen` method that can adapt them to a diferent type of error. For example to adapt a `Retry[Throwable]` to a `Retry[PolicyError[Throwable]]`:
+
+```scala
+val retry: Retry[Throwable] = ???
+val retryComposable = retry.widen[PolicyError[Throwable]] { case Policy.WrappedError(e) => e }
+```
+
+The partial function above is made available as `Policy#unwrap[E]` for convenience, so that the above can be written as
+
+```scala
+val retryComposable: Retry[PolicyError[Throwable]] = retry.widen(Policy.unwrap[Throwable])
+```
+
+Many variations of policy combinations are possible. The `polly` project has some good advice for the order in which to compose policies: https://github.com/App-vNext/Polly/wiki/PolicyWrap#usage-recommendations.

--- a/docs/docs/docs/combining.md
+++ b/docs/docs/docs/combining.md
@@ -28,7 +28,7 @@ Composing policies requires some special care in handling policy errors, behavio
 
 1. Behavior: what is the desired retry behavior when a circuit breaker error is encountered? Should the call be retried or the error passed through to the caller? 
 
-2. Types: because a `Retry` is created with a `Schedule` that expects a certain type `E` of errors as input, a `Retry[E]` cannot be applied on ZIO[R, CircuitBreaker[E], A] effects.
+2. Types: because a `Retry` is created with a `Schedule` that expects a certain type `E` of errors as input, a `Retry[E]` cannot be applied on `ZIO[R, CircuitBreakerError[E], A]` effects.
 
 For these cases, the `Retry` and `CircuitBreaker` policies have a `widen` method that can adapt them to a diferent type of error. For example to adapt a `Retry[Throwable]` to a `Retry[PolicyError[Throwable]]`:
 

--- a/docs/docs/docs/combining.md
+++ b/docs/docs/docs/combining.md
@@ -13,14 +13,11 @@ Many variations of policy combinations are possible, but one example is to have 
 To compose policies, convert them into a `Policy` instance using `toPolicy` and use `.compose` to wrap it in another policy. For example:
 
 ```scala
-val policy: ZManaged[Clock, Nothing, Policy[Any, Any]] = for {
-  rateLimiter <- RateLimiter.make(1, 2.seconds)
-  bulkhead    <- Bulkhead.make(2)
-  retry       <- Retry.make(Schedule.recurs(3))
-} yield bulkhead
-  .toPolicy[Any] compose rateLimiter.toPolicy[Any] compose retry.toPolicy[Any]
+val policy: ZManaged[Clock, Nothing, Policy[Any]] = for {
+rateLimiter <- RateLimiter.make(1, 2.seconds)
+bulkhead    <- Bulkhead.make(2)
+retry       <- Retry.make(Schedule.recurs(3))
+} yield bulkhead.toPolicy compose rateLimiter.toPolicy compose retry.toPolicy
 ```
-
-Unfortunately the type inference here is not quite there yet, requiring the `Any` type parameters. 
 
 Because of type-safety, you sometimes need to transform your individual policies to work with the errors produced by inner policies. Take for example, a Retry around a `CircuitBreaker` that you want to call with. If you want to retry on any error, a `Retry[Any]` is fine. But if you only want to use a Retry on ZIOs with error type `E` and your Retry policy defines that it only wants to retry a subset of those errors, eg `E1 <: E`, you will need to adapt it to decide what to do with the `CircuitBreakerError[E]` that is the output error type of the `CircuitBreaker`. 

--- a/docs/docs/docs/general_usage.md
+++ b/docs/docs/docs/general_usage.md
@@ -29,6 +29,17 @@ CircuitBreaker.withMaxFailures(3, isFailure = isFailure).use { circuitBreaker =>
 }
 ```
 
+## Mapping errors
+
+`rezilience` policies are type-safe in the error channel, which means that they change the error type of the effects they are applied to. For example, applying a `CircuitBreaker` to an effect of type `ZIO[Any, Throwable, Unit]` will result in a `ZIO[Any, CircuitBreakerError[Throwable], Unit]`. You will need to handle this error explicitly. Some convenience methods are made available on the `CircuitBreakerError` for this:
+
+* `CircuitBreakerError#fold[O](circuitBreakerOpen: O, unwrap: E => O)`  
+  Convert a `CircuitBreakerOpen` or a `WrappedError` into an `O`.
+* `.toException`  
+  Converts a `CircuitBreakerError` to a `CircuitBreakerException`.
+
+Similar methods exist on `BulkheadError` and `PolicyError` (see [Bulkhead](bulkhead.md) and [Combining Policiesa](combining.md))
+
 ## ZLayer integration
 You can apply `rezilience` policies at the level of an individual ZIO effect. But having to wrap all your calls in eg a rate limiter can clutter your code somewhat. When you are using the ZIO module pattern using `ZLayer`, it is also possible to integrate a `rezilience` policy with some service at the `ZLayer` level. In the spirit of aspect oriented programming, the code using your service will not be cluttered with the aspect of rate limiting.
 
@@ -48,7 +59,7 @@ ZLayer.fromServiceManaged { database: Database.Service =>
 val env: ZLayer[Clock, Nothing, Database] = (Clock.live ++ databaseLayer) >>> addRateLimiterToDatabase
 ```
 
-This works well for policies that do not alter the error type like RateLimiter and Retry, but for policies that do alter the error type, you will need to map eg a `CircuitBreakerOpen` to the error type in your service definition. For cases where your service's error type is `Throwable`, you can convert a `PolicyError` to an `Exception` using `.toException`. For custom error types this is not possible. In that case you can define a new service type like `ResilientDatabase` where the error types are `PolicyError[E]`.
+This works well for policies that do not alter the error type like RateLimiter and Retry, but for policies that do alter the error type, you will need to map eg a `CircuitBreakerOpen` to the error type in your service definition. For cases where your service's error type is `Throwable`, you can convert a `CircuitBreakerError`, `BulkheadError` or `PolicyError` to an `Exception` using `.toException`. For custom error types this is not possible. In that case you can define a new service type like `ResilientDatabase` where the error types are `PolicyError[E]`.
 
 See the [full example](rezilience/shared/src/test/scala/nl/vroste/rezilience/examples/ZLayerIntegrationExample.scala) for more.
 

--- a/docs/docs/docs/general_usage.md
+++ b/docs/docs/docs/general_usage.md
@@ -38,7 +38,7 @@ CircuitBreaker.withMaxFailures(3, isFailure = isFailure).use { circuitBreaker =>
 * `.toException`  
   Converts a `CircuitBreakerError` to a `CircuitBreakerException`.
 
-Similar methods exist on `BulkheadError` and `PolicyError` (see [Bulkhead](bulkhead.md) and [Combining Policiesa](combining.md))
+Similar methods exist on `BulkheadError` and `PolicyError` (see [Bulkhead](bulkhead.md) and [Combining Policies](combining.md))
 
 ## ZLayer integration
 You can apply `rezilience` policies at the level of an individual ZIO effect. But having to wrap all your calls in eg a rate limiter can clutter your code somewhat. When you are using the ZIO module pattern using `ZLayer`, it is also possible to integrate a `rezilience` policy with some service at the `ZLayer` level. In the spirit of aspect oriented programming, the code using your service will not be cluttered with the aspect of rate limiting.
@@ -59,11 +59,6 @@ ZLayer.fromServiceManaged { database: Database.Service =>
 val env: ZLayer[Clock, Nothing, Database] = (Clock.live ++ databaseLayer) >>> addRateLimiterToDatabase
 ```
 
-This works well for policies that do not alter the error type like RateLimiter and Retry, but for policies that do alter the error type, you will need to map eg a `CircuitBreakerOpen` to the error type in your service definition. For cases where your service's error type is `Throwable`, you can convert a `CircuitBreakerError`, `BulkheadError` or `PolicyError` to an `Exception` using `.toException`. For custom error types this is not possible. In that case you can define a new service type like `ResilientDatabase` where the error types are `PolicyError[E]`.
+This works well for policies that do not alter the error type like RateLimiter and Retry, but for policies that do alter the error type, you will need to map eg a `CircuitBreakerOpen` to the error type in your service definition. For cases where your service's error type is `Throwable`, you can easily convert a `CircuitBreakerError`, `BulkheadError` or `PolicyError` to an `Exception` using `.toException`. Otherwise it is recommended to have something like a general `case class UnknownServiceError(e: Exception)` in your service error type, to which you can map policy errors. If that is not possible for some reason, you can also define a new service type like `ResilientDatabase` where the error types are `PolicyError[E]`.
 
 See the [full example](rezilience/shared/src/test/scala/nl/vroste/rezilience/examples/ZLayerIntegrationExample.scala) for more.
-
-
-
-
-

--- a/docs/docs/docs/general_usage.md
+++ b/docs/docs/docs/general_usage.md
@@ -48,7 +48,7 @@ ZLayer.fromServiceManaged { database: Database.Service =>
 val env: ZLayer[Clock, Nothing, Database] = (Clock.live ++ databaseLayer) >>> addRateLimiterToDatabase
 ```
 
-This works well for policies that do not alter the error type like RateLimiter and Retry, but for policies that do alter the error type, you will need to map eg a `CircuitBreakerOpen` to the error type in your service definition. If your service's error type is something like `Throwable`, you can throw any new kind of exception, but for custom error types this is not possible. In that case you can define a new service type like `ResilientDatabase` where the error types are `PolicyError[E]`.
+This works well for policies that do not alter the error type like RateLimiter and Retry, but for policies that do alter the error type, you will need to map eg a `CircuitBreakerOpen` to the error type in your service definition. For cases where your service's error type is `Throwable`, you can convert a `PolicyError` to an `Exception` using `.toException`. For custom error types this is not possible. In that case you can define a new service type like `ResilientDatabase` where the error types are `PolicyError[E]`.
 
 See the [full example](rezilience/shared/src/test/scala/nl/vroste/rezilience/examples/ZLayerIntegrationExample.scala) for more.
 

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
@@ -27,8 +27,9 @@ trait Bulkhead { self =>
    */
   def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A]
 
-  def toPolicy[E]: Policy[E, BulkheadError[E]] = new Policy[E, BulkheadError[E]] {
-    override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, BulkheadError[E1], A] = self(f)
+  def toPolicy: Policy[Any] = new Policy[Any] {
+    override def apply[R, E1 <: Any, A](f: ZIO[R, E1, A]): ZIO[R, Policy.PolicyError[E1], A] =
+      self(f).mapError(Policy.bulkheadErrorToPolicyError)
   }
 
   /**

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
@@ -1,7 +1,6 @@
 package nl.vroste.rezilience
 
 import nl.vroste.rezilience.Bulkhead._
-import nl.vroste.rezilience.Policy.PolicyError
 import zio._
 import zio.stream.ZStream
 

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -13,33 +13,34 @@ import zio.stream.ZStream
  * Operates in three states:
  *
  * - Closed (initial state / normal operation): calls are let through normally. Call failures and successes
- *   update the call statistics, eg failure count. When the statistics satisfy some criteria, the circuit
- *   breaker is 'tripped' and set to the Open state. Note that after this switch, in-flight calls are not canceled.
- *   Their success  or failure does not affect the circuit breaker anymore though.
+ * update the call statistics, eg failure count. When the statistics satisfy some criteria, the circuit
+ * breaker is 'tripped' and set to the Open state. Note that after this switch, in-flight calls are not canceled.
+ * Their success  or failure does not affect the circuit breaker anymore though.
  *
  * - Open: all calls fail fast with a `CircuitBreakerOpen` error. After the reset timeout,
- *   the states changes to HalfOpen
+ * the states changes to HalfOpen
  *
  * - HalfOpen: the first call is let through. Meanwhile all other calls fail with a
- *   `CircuitBreakerOpen` error. If the first call succeeds, the state changes to
- *   Closed again (normal operation). If it fails, the state changes back to Open.
- *   The reset timeout is governed by a reset policy, which is typically an exponential backoff.
+ * `CircuitBreakerOpen` error. If the first call succeeds, the state changes to
+ * Closed again (normal operation). If it fails, the state changes back to Open.
+ * The reset timeout is governed by a reset policy, which is typically an exponential backoff.
  *
  * Two tripping strategies are implemented:
  * 1) Failure counting. When the number of successive failures exceeds a threshold, the circuit
- *    breaker is tripped.
+ * breaker is tripped.
  *
- *   Note that the maximum number of failures before tripping the circuit breaker is not absolute under
- *   concurrent execution. I.e. if you make 20 calls to a failing system in parallel via a circuit breaker
- *   with max 10 failures, the calls will be running concurrently. The circuit breaker will trip
- *   after 10 calls, but the remaining 10 that are in-flight will continue to run and fail as well.
+ * Note that the maximum number of failures before tripping the circuit breaker is not absolute under
+ * concurrent execution. I.e. if you make 20 calls to a failing system in parallel via a circuit breaker
+ * with max 10 failures, the calls will be running concurrently. The circuit breaker will trip
+ * after 10 calls, but the remaining 10 that are in-flight will continue to run and fail as well.
  *
- *   TODO what to do if you want this kind of behavior, or should we make it an option?
+ * TODO what to do if you want this kind of behavior, or should we make it an option?
  *
  * 2) Failure rate. When the fraction of failed calls in some sample period exceeds
- *    a threshold (between 0 and 1), the circuit breaker is tripped.
+ * a threshold (between 0 and 1), the circuit breaker is tripped.
  */
-trait CircuitBreaker[-E] { self =>
+trait CircuitBreaker[-E] {
+  self =>
 
   /**
    * Execute a given effect with the circuit breaker
@@ -51,34 +52,51 @@ trait CircuitBreaker[-E] { self =>
   def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A]
 
   def toPolicy: Policy[E] = new Policy[E] {
-    override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, PolicyError[E1], A]               =
+    override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, PolicyError[E1], A] =
       self(f).mapError(circuitBreakerErrorToPolicyError)
-    override def applyP[R, E1 <: E, A](f: ZIO[R, PolicyError[E1], A]): ZIO[R, PolicyError[E1], A] = ???
   }
+
+  /**
+   * Transform this policy to apply to larger class of errors
+   *
+   * Only where the partial function is defined will the policy be applied, other errors are not retried
+   *
+   * @param pf
+   * @tparam E2
+   * @return
+   */
+  def widen[E2](pf: PartialFunction[E2, E]): CircuitBreaker[E2]
 }
 
 object CircuitBreaker {
+
   import State._
 
   sealed trait CircuitBreakerCallError[+E]
-  case object CircuitBreakerOpen       extends CircuitBreakerCallError[Nothing]
+
+  case object CircuitBreakerOpen extends CircuitBreakerCallError[Nothing]
+
   case class WrappedError[E](error: E) extends CircuitBreakerCallError[E]
 
   sealed trait State
 
   object State {
-    case object Closed   extends State
+
+    case object Closed extends State
+
     case object HalfOpen extends State
-    case object Open     extends State
+
+    case object Open extends State
+
   }
 
   /**
    * Create a CircuitBreaker that fails when a number of successive failures (no pun intended) has been counted
    *
-   * @param maxFailures Maximum number of failures before tripping the circuit breaker
-   * @param resetPolicy Reset schedule after too many failures. Typically an exponential backoff strategy is used.
-   * @param isFailure Only failures that match according to `isFailure` are treated as failures by the circuit breaker.
-   *                  Other failures are passed on, circumventing the circuit breaker's failure counter.
+   * @param maxFailures   Maximum number of failures before tripping the circuit breaker
+   * @param resetPolicy   Reset schedule after too many failures. Typically an exponential backoff strategy is used.
+   * @param isFailure     Only failures that match according to `isFailure` are treated as failures by the circuit breaker.
+   *                      Other failures are passed on, circumventing the circuit breaker's failure counter.
    * @param onStateChange Observer for circuit breaker state changes
    * @return The CircuitBreaker as a managed resource
    */
@@ -94,10 +112,10 @@ object CircuitBreaker {
    * Create a CircuitBreaker with the given tripping strategy
    *
    * @param trippingStrategy Determines under which conditions the CircuitBraker trips
-   * @param resetPolicy Reset schedule after too many failures. Typically an exponential backoff strategy is used.
-   * @param isFailure Only failures that match according to `isFailure` are treated as failures by the circuit breaker.
-   *                  Other failures are passed on, circumventing the circuit breaker's failure counter.
-   * @param onStateChange Observer for circuit breaker state changes
+   * @param resetPolicy      Reset schedule after too many failures. Typically an exponential backoff strategy is used.
+   * @param isFailure        Only failures that match according to `isFailure` are treated as failures by the circuit breaker.
+   *                         Other failures are passed on, circumventing the circuit breaker's failure counter.
+   * @param onStateChange    Observer for circuit breaker state changes
    * @return
    */
   def make[E](
@@ -124,57 +142,87 @@ object CircuitBreaker {
                           }
                           .runDrain
                           .forkManaged
-    } yield new CircuitBreaker[E] {
+    } yield new CircuitBreakerImpl[E](
+      state,
+      resetRequests,
+      strategy,
+      onStateChange,
+      schedule,
+      isFailure,
+      halfOpenSwitch
+    )
 
-      val changeToOpen = state.set(Open) *>
-        resetRequests.offer(()) <*
-        onStateChange(Open).fork // Do not wait for user code
+  private case class CircuitBreakerImpl[-E](
+    state: Ref[State],
+    resetRequests: Queue[Unit],
+    strategy: TrippingStrategy,
+    onStateChange: State => UIO[Unit],
+    schedule: Schedule.Driver[Clock, Any, Any],
+    isFailure: PartialFunction[E, Boolean],
+    halfOpenSwitch: Ref[Boolean]
+  ) extends CircuitBreaker[E] {
 
-      val changeToClosed = strategy.onReset *>
-        schedule.reset *>
-        state.set(Closed) <*
-        onStateChange(Closed).fork // Do not wait for user code
+    val changeToOpen = state.set(Open) *>
+      resetRequests.offer(()) <*
+      onStateChange(Open).fork // Do not wait for user code
 
-      override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A] =
-        for {
-          currentState <- state.get
-          result       <- currentState match {
-                            case Closed   =>
-                              // The state may have already changed to Open or even HalfOpen.
-                              // This can happen if we fire X calls in parallel where X >= 2 * maxFailures
-                              def onFail =
-                                (strategy.onFailure *>
-                                  ZIO.whenM(state.get.flatMap(s => strategy.shouldTrip.map(_ && (s == Closed)))) {
-                                    changeToOpen
-                                  }).uninterruptible
+    val changeToClosed = strategy.onReset *>
+      schedule.reset *>
+      state.set(Closed) <*
+      onStateChange(Closed).fork // Do not wait for user code
 
-                              f.either.flatMap {
-                                case Left(e) if isFailure.isDefinedAt(e) => ZIO.fail(e)
-                                case Left(e)                             => ZIO.left(WrappedError(e))
-                                case Right(e)                            => ZIO.right(e)
+    override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, CircuitBreakerCallError[E1], A] =
+      for {
+        currentState <- state.get
+        result       <- currentState match {
+                          case Closed   =>
+                            // The state may have already changed to Open or even HalfOpen.
+                            // This can happen if we fire X calls in parallel where X >= 2 * maxFailures
+                            def onFail =
+                              (strategy.onFailure *>
+                                ZIO.whenM(state.get.flatMap(s => strategy.shouldTrip.map(_ && (s == Closed)))) {
+                                  changeToOpen
+                                }).uninterruptible
 
-                              }
-                                .tapBoth(_ => onFail, _ => strategy.onSuccess)
-                                .mapError(WrappedError(_))
-                                .absolve
-                            case Open     =>
-                              ZIO.fail(CircuitBreakerOpen)
-                            case HalfOpen =>
-                              for {
-                                isFirstCall <- halfOpenSwitch.getAndUpdate(_ => false)
-                                result      <- if (isFirstCall) {
-                                                 f.mapError(WrappedError(_))
-                                                   .tapBoth(
-                                                     _ => (strategy.onFailure *> changeToOpen).uninterruptible,
-                                                     _ => (changeToClosed *> strategy.onReset).uninterruptible
-                                                   )
-                                               } else {
-                                                 ZIO.fail(CircuitBreakerOpen)
-                                               }
-                              } yield result
-                          }
-        } yield result
-    }
+                            f.either.flatMap {
+                              case Left(e) if isFailure.isDefinedAt(e) => ZIO.fail(e)
+                              case Left(e)                             => ZIO.left(WrappedError(e))
+                              case Right(e)                            => ZIO.right(e)
 
-  private def isFailureAny[E]: PartialFunction[E, Boolean] = { case _ => true }
+                            }
+                              .tapBoth(_ => onFail, _ => strategy.onSuccess)
+                              .mapError(WrappedError(_))
+                              .absolve
+                          case Open     =>
+                            ZIO.fail(CircuitBreakerOpen)
+                          case HalfOpen =>
+                            for {
+                              isFirstCall <- halfOpenSwitch.getAndUpdate(_ => false)
+                              result      <- if (isFirstCall) {
+                                               f.mapError(WrappedError(_))
+                                                 .tapBoth(
+                                                   _ => (strategy.onFailure *> changeToOpen).uninterruptible,
+                                                   _ => (changeToClosed *> strategy.onReset).uninterruptible
+                                                 )
+                                             } else {
+                                               ZIO.fail(CircuitBreakerOpen)
+                                             }
+                            } yield result
+                        }
+      } yield result
+
+    def widen[E2](pf: PartialFunction[E2, E]): CircuitBreaker[E2] = CircuitBreakerImpl[E2](
+      state,
+      resetRequests,
+      strategy,
+      onStateChange,
+      schedule,
+      pf andThen isFailure,
+      halfOpenSwitch
+    )
+  }
+
+  private def isFailureAny[E]: PartialFunction[E, Boolean] = { case _ =>
+    true
+  }
 }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -59,11 +59,12 @@ trait CircuitBreaker[-E] {
   /**
    * Transform this policy to apply to larger class of errors
    *
-   * Only where the partial function is defined will the policy be applied, other errors are not retried
+   * Only for errors where the partial function is defined will errors be considered as failures, otherwise
+   * the error is passed through to the caller
    *
-   * @param pf
+   * @param pf Map an error of type E2 to an error of type E
    * @tparam E2
-   * @return
+   * @return A new CircuitBreaker defined for failures of type E2
    */
   def widen[E2](pf: PartialFunction[E2, E]): CircuitBreaker[E2]
 }
@@ -73,21 +74,15 @@ object CircuitBreaker {
   import State._
 
   sealed trait CircuitBreakerCallError[+E]
-
-  case object CircuitBreakerOpen extends CircuitBreakerCallError[Nothing]
-
+  case object CircuitBreakerOpen       extends CircuitBreakerCallError[Nothing]
   case class WrappedError[E](error: E) extends CircuitBreakerCallError[E]
 
   sealed trait State
 
   object State {
-
-    case object Closed extends State
-
+    case object Closed   extends State
     case object HalfOpen extends State
-
-    case object Open extends State
-
+    case object Open     extends State
   }
 
   /**
@@ -222,7 +217,5 @@ object CircuitBreaker {
     )
   }
 
-  private def isFailureAny[E]: PartialFunction[E, Boolean] = { case _ =>
-    true
-  }
+  private def isFailureAny[E]: PartialFunction[E, Boolean] = { case _ => true }
 }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Policy.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Policy.scala
@@ -34,6 +34,12 @@ trait Policy[-E] { self =>
 object Policy {
   sealed trait PolicyError[+E] { self =>
     def toException: Exception = PolicyException(self)
+
+    def fold[O](bulkheadRejection: O, circuitBreakerOpen: O, unwrap: E => O): O = self match {
+      case BulkheadRejection   => bulkheadRejection
+      case CircuitBreakerOpen  => circuitBreakerOpen
+      case WrappedError(error) => unwrap(error)
+    }
   }
 
   case class WrappedError[E](e: E) extends PolicyError[E]

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Policy.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Policy.scala
@@ -102,16 +102,6 @@ object Policy {
     override def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] = task
   }
 
-  def circuitBreakerErrorToPolicyError[E]: CircuitBreakerCallError[E] => PolicyError[E] = {
-    case CircuitBreaker.CircuitBreakerOpen => CircuitBreakerOpen
-    case CircuitBreaker.WrappedError(e)    => WrappedError(e)
-  }
-
-  def bulkheadErrorToPolicyError[E]: BulkheadError[E] => PolicyError[E] = {
-    case Bulkhead.BulkheadRejection => BulkheadRejection
-    case Bulkhead.WrappedError(e)   => WrappedError(e)
-  }
-
   def flattenWrappedError[E]: PolicyError[PolicyError[E]] => PolicyError[E] = {
     case WrappedError(e)    => e
     case CircuitBreakerOpen => CircuitBreakerOpen

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -25,10 +25,8 @@ trait RateLimiter { self =>
   def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A]
 
   def toPolicy: Policy[Any] = new Policy[Any] {
-    override def apply[R, E1 <: Any, A](f: ZIO[R, E1, A]): ZIO[R, Policy.PolicyError[E1], A]                      =
+    override def apply[R, E1 <: Any, A](f: ZIO[R, E1, A]): ZIO[R, Policy.PolicyError[E1], A] =
       self(f).mapError(Policy.WrappedError(_))
-    override def applyP[R, E1 <: Any, A](f: ZIO[R, Policy.PolicyError[E1], A]): ZIO[R, Policy.PolicyError[E1], A] =
-      self(f)
   }
 }
 

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -24,8 +24,11 @@ trait RateLimiter { self =>
    */
   def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A]
 
-  def toPolicy[E]: Policy[E, E] = new Policy[E, E] {
-    override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, E1, A] = self(f)
+  def toPolicy: Policy[Any] = new Policy[Any] {
+    override def apply[R, E1 <: Any, A](f: ZIO[R, E1, A]): ZIO[R, Policy.PolicyError[E1], A]                      =
+      self(f).mapError(Policy.WrappedError(_))
+    override def applyP[R, E1 <: Any, A](f: ZIO[R, Policy.PolicyError[E1], A]): ZIO[R, Policy.PolicyError[E1], A] =
+      self(f)
   }
 }
 

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Retry.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Retry.scala
@@ -1,7 +1,7 @@
 package nl.vroste.rezilience
 import zio.clock.Clock
 import zio.duration._
-import zio.{ Ref, Schedule, ZIO, ZManaged }
+import zio.{ Schedule, ZIO, ZManaged }
 
 trait Retry[-E] { self =>
   def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, E1, A]
@@ -15,23 +15,7 @@ trait Retry[-E] { self =>
    * @tparam E2
    * @return
    */
-  def widen[E2](pf: PartialFunction[E2, E]): Retry[E2] = new Retry[E2] {
-    override def apply[R, E1 <: E2, A](f: ZIO[R, E1, A]): ZIO[R, E1, A] = for {
-      lastError                      <- Ref.make[Option[E1]](None)
-      // We lose access to the E2 type error when we convert it using the partial function, so store it in a ref
-      inner: ZIO[R, E, Either[E1, A]] =
-        f.foldM(
-          e2 =>
-            lastError.set(Some(e2)) *>
-              pf
-                .andThen(ZIO.fail(_))
-                .lift(e2)
-                .getOrElse(ZIO.left(e2)),
-          ZIO.right(_)
-        )
-      result                         <- self.apply(inner).flatMapError(_ => lastError.get).mapError(_.get).absolve
-    } yield result
-  }
+  def widen[E2](pf: PartialFunction[E2, E]): Retry[E2]
 
   def toPolicy: Policy[E] = new Policy[E] {
     override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, Policy.PolicyError[E1], A] =
@@ -67,10 +51,17 @@ object Retry {
   }
 
   def make[E](schedule: Schedule[Any, E, Any]): ZManaged[Clock, Nothing, Retry[E]] =
-    for {
-      clock <- ZManaged.environment[Clock]
-    } yield new Retry[E] {
-      override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, E1, A] =
-        ZIO.environment[R].flatMap(env => f.provide(env).retry(schedule).provide(clock))
-    }
+    ZManaged.environment[Clock].map(RetryImpl(_, schedule))
+
+  private case class RetryImpl[-E](clock: Clock, schedule: Schedule[Any, E, Any]) extends Retry[E] {
+    override def apply[R, E1 <: E, A](f: ZIO[R, E1, A]): ZIO[R, E1, A] =
+      ZIO.environment[R].flatMap(env => f.provide(env).retry(schedule).provide(clock))
+
+    override def widen[E2](pf: PartialFunction[E2, E]): Retry[E2] = RetryImpl[E2](
+      clock,
+      (zio.Schedule.stop ||| schedule).contramap[Any, E2] { e2 =>
+        pf.andThen(Right.apply[E2, E](_)).applyOrElse(e2, Left.apply[E2, E](_))
+      }
+    )
+  }
 }

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/RetrySpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/RetrySpec.scala
@@ -1,0 +1,25 @@
+package nl.vroste.rezilience
+
+import nl.vroste.rezilience.Policy.CircuitBreakerOpen
+import zio.duration._
+import zio.test.Assertion._
+import zio.test._
+import zio.{ Ref, ZIO }
+
+object RetrySpec extends DefaultRunnableSpec {
+  override def spec = suite("Retry")(
+    testM("widen should not retry unmatched errors") {
+      Retry
+        .make[Throwable](Retry.Schedule.exponentialBackoff(1.second, 2.seconds))
+        .map(_.widen(Policy.unwrap[Throwable]))
+        .use { retry =>
+          for {
+            tries     <- Ref.make(0)
+            failure    = ZIO.fail(CircuitBreakerOpen)
+            _         <- retry(tries.update(_ + 1).flatMap(_ => failure).unit).either
+            triesMade <- tries.get
+          } yield assert(triesMade)(equalTo(1))
+        }
+    }
+  )
+}

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/examples/ZLayerIntegrationExample.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/examples/ZLayerIntegrationExample.scala
@@ -1,7 +1,7 @@
 package nl.vroste.rezilience.examples
 
 import nl.vroste.rezilience.Policy.PolicyError
-import nl.vroste.rezilience.{ CircuitBreaker, Policy, RateLimiter }
+import nl.vroste.rezilience.{ CircuitBreaker, RateLimiter }
 import zio._
 import zio.clock.Clock
 
@@ -74,7 +74,7 @@ object ZLayerIntegrationExample extends zio.App {
     ZLayer.fromServiceManaged { database: Database.Service =>
       CircuitBreaker
         .withMaxFailures[Throwable](10)
-        .map(_.toPolicy[Throwable].mapError(Policy.circuitBreakerErrorToPolicyError))
+        .map(_.toPolicy)
         .map { rl =>
           new ResilientDatabase.Service {
             override def transfer(amount: Amount, from: Account, to: Account): ZIO[Any, PolicyError[Throwable], Unit] =


### PR DESCRIPTION
* Remove second type parameter on `Policy` to make all policies have a `PolicyError[E]` type. This enhances composition.
* Add `widen` to `Retry` and `CircuitBreaker` to ease composition
* Add `fold` and `toException` methods to policy errors (`CircuitBreakerError`, `BulkheadError` and `PolicyError`)
* Extend documentation