### PR TITLE
Add support for schedules with an environment requirement to Retry

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Retry.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Retry.scala
@@ -1,7 +1,6 @@
 package nl.vroste.rezilience
 import zio.clock.Clock
 import zio.duration._
-import zio.random.Random
 import zio.{ Schedule, ZIO, ZManaged }
 
 trait Retry[-E] { self =>
@@ -73,7 +72,7 @@ object Retry {
     min: Duration = 1.second,
     max: Duration = 1.minute,
     factor: Double = 2.0
-  ): ZManaged[Clock with Random, Nothing, Retry[Any]] =
+  ): ZManaged[Clock, Nothing, Retry[Any]] =
     ZManaged.environment[Clock].map(RetryImpl(_, Schedule.exponentialBackoff(min, max, factor)))
 
   private case class RetryImpl[-E, ScheduleEnv](

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/RetrySpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/RetrySpec.scala
@@ -11,7 +11,7 @@ object RetrySpec extends DefaultRunnableSpec {
   override def spec = suite("Retry")(
     testM("widen should not retry unmatched errors") {
       Retry
-        .make[Throwable](Retry.Schedule.exponentialBackoff(1.second, 2.seconds))
+        .make(Retry.Schedule.exponentialBackoff(1.second, 2.seconds))
         .map(_.widen(Policy.unwrap[Throwable]))
         .use { retry =>
           for {


### PR DESCRIPTION
+ add convenience `Retry.make` which creates an exponential retry