### PR TITLE
Improved RateLimiter interruption behavior

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -19,11 +19,10 @@ trait RateLimiter { self =>
   /**
    * Execute the task with RateLimiter protection
    *
-   * The effect returned by this method can be safely interrupted. If the task is still waiting in the rate limiter queue,
-   * the task will not begin execution anymore. However the interrupted call will still need to pass through the rate limiter throttle,
-   * so the next queued call will possibly be delayed according to rate limiting parameters.
-   *
-   * If the task has already started execution, interruption will be completed when the task is interrupted.
+   * The effect returned by this method can be interrupted, which is handled as follows:
+   * - If the task is still waiting in the rate limiter queue, it will not start execution.
+   *   It will also not count for the rate limiting or hold back other uninterrupted queued tasks.
+   * - If the task has already started executing, interruption will interrupt the task and will complete when the task's interruption is complete.
    *
    * @param task Task to execute. When the rate limit is exceeded, the call will be postponed.
    */

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -56,7 +56,7 @@ object RateLimiter {
       p           <- Promise.make[E, A]
       interrupted <- Promise.make[Nothing, Unit]
       env         <- ZIO.environment[R]
-      effect       = task.foldM(p.fail, p.succeed).provide(env) raceFirst interrupted.await
+      effect       = (interrupted.await raceFirst task.foldM(p.fail, p.succeed).provide(env)).unlessM(interrupted.isDone)
       result      <- (q.offer(effect) *> p.await).onInterrupt(interrupted.succeed(()))
     } yield result
   }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -17,10 +17,15 @@ import zio.clock.Clock
 trait RateLimiter { self =>
 
   /**
-   * Call the system with RateLimiter protection
+   * Execute the task with RateLimiter protection
    *
-   * @param task Task to execute. When the rate limit is exceeded, the call will be postponed. The environment of the
-   *             task i
+   * The effect returned by this method can be safely interrupted. If the task is still waiting in the rate limiter queue,
+   * the task will not begin execution anymore. However the interrupted call will still need to pass through the rate limiter throttle,
+   * so the next queued call will possibly be delayed according to rate limiting parameters.
+   *
+   * If the task has already started execution, it will be interrupted in the background.
+   *
+   * @param task Task to execute. When the rate limit is exceeded, the call will be postponed.
    */
   def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A]
 

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -48,12 +48,12 @@ object RateLimiter {
    * @param interval Interval duration
    * @return RateLimiter
    */
-  def make(max: Long, interval: Duration = 1.second): ZManaged[Clock, Nothing, RateLimiter] = for {
+  def make(max: Int, interval: Duration = 1.second): ZManaged[Clock, Nothing, RateLimiter] = for {
     q <- Queue.unbounded[UIO[Any]].toManaged_
     _ <- ZStream
-           .fromQueue(q)
+           .fromQueue(q, maxChunkSize = max)
            // TODO filter out already interrupted stuff?
-           .throttleShape(max, interval, max)(_.size.toLong)
+           .throttleShape(max.toLong, interval, max.toLong)(_.size.toLong)
            .mapMParUnordered(Int.MaxValue)(identity)
            .runDrain
            .forkManaged

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/RateLimiterSpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/RateLimiterSpec.scala
@@ -1,10 +1,12 @@
 package nl.vroste.rezilience
-import zio.{ clock, Promise, ZIO }
+import zio.{ clock, Promise, Ref, ZIO }
 import zio.duration._
 import zio.test._
 import zio.test.Assertion._
-import zio.test.TestAspect.{ nonFlaky, timeout }
+import zio.test.TestAspect.{ diagnose, nonFlaky, timeout }
 import zio.test.environment.TestClock
+
+import java.time.Instant
 
 object RateLimiterSpec extends DefaultRunnableSpec {
   override def spec = suite("RateLimiter")(
@@ -62,7 +64,33 @@ object RateLimiterSpec extends DefaultRunnableSpec {
           _           <- interrupted.await
         } yield assertCompletes
       }
+    },
+    testM("will not start execution of an effect when it is interrupted before getting its turn to execute") {
+      RateLimiter.make(1, 1.second).use { rl =>
+        for {
+          count        <- Ref.make(0)
+          _            <- rl(ZIO.unit)
+          fib          <- rl(count.set(1)).fork
+          interruption <- fib.interrupt.fork
+          _            <- interruption.join
+          c            <- count.get
+        } yield assert(c)(equalTo(0))
+      }
+    },
+    testM("will make effects wait for interrupted effects to pass through the rate limiter") {
+      RateLimiter.make(1, 1.second).use { rl =>
+        for {
+          _  <- rl(ZIO.unit) // Execute one
+          f1 <- rl(ZIO.unit).fork
+          _  <- TestClock.adjust(1.second) // This ensures that the second RL call is in the stream before we interrupt
+          _  <- f1.interrupt
 
+          // This one will have to wait 1 seconds
+          fib               <- rl(clock.instant).fork
+          _                 <- TestClock.adjust(1.second)
+          lastExecutionTime <- fib.join
+        } yield assert(lastExecutionTime)(equalTo(Instant.ofEpochSecond(2)))
+      }
     }
-  ) @@ nonFlaky @@ timeout(60.seconds)
+  ) @@ timeout(10.seconds) @@ diagnose(10.seconds) @@ nonFlaky
 }


### PR DESCRIPTION
* Do not start the task after rate limiting when already interrupted.
* Filter out already interrupted tasks before passing through throttling. 
* When interrupting a task that has already started executing, wait for its interruption to complete.
* Use a more efficient bounded queue of next power of 2 (more efficient implementation) instead of an unbounded queue. Backpressure may now also originate from the queue instead of just the throttling.