### PR TITLE
Simplify RateLimiter and Bulkhead implementations

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
@@ -89,18 +89,21 @@ object Bulkhead {
       override def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A] =
         for {
           // Atomically enqueue if there's still enough room, otherwise fail with BulkheadRejection
-          start  <- Promise.make[Nothing, Unit]
-          done   <- Promise.make[Nothing, Unit]
-          action  = start.succeed(()) *> done.await
+          start        <- Promise.make[Nothing, Unit]
+          done         <- Promise.make[Nothing, Unit]
+          action        = start.succeed(()) *> done.await
           // Atomically enqueue and update queue state if there's still enough room, otherwise fail with BulkheadRejection
-          _      <-
+          enqueueAction =
             inFlightAndQueued.modify { state =>
               if (state.total < maxInFlightCalls + maxQueueing)
                 (queue.offer(action), state.enqueue)
               else
                 (ZIO.fail(BulkheadRejection), state)
+
             }.flatten.uninterruptible
-          result <- start.await.bracket_(done.succeed(()), task.mapError(WrappedError(_)))
+          result       <- ZManaged
+                            .makeInterruptible_(enqueueAction)(done.succeed(()))
+                            .use_(start.await *> task.mapError(WrappedError(_)))
         } yield result
 
       override def metrics: UIO[Metrics] = (inFlightAndQueued.get.map(state => Metrics(state.inFlight, state.enqueued)))

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -61,23 +61,14 @@ object RateLimiter extends RateLimiterPlatformSpecificObj {
              .forkManaged
     } yield new RateLimiter {
       override def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] = for {
-
-        p              <- Promise.make[E, A]
-        interrupted    <- Promise.make[Nothing, Unit]
-        env            <- ZIO.environment[R]
-        started        <- Semaphore.make(1)
+        start          <- Promise.make[Nothing, Unit]
+        done           <- Promise.make[Nothing, Unit]
         interruptedRef <- Ref.make(false)
-        effect          =
-          started
-            .withPermit(interrupted.await raceFirst task.foldM(p.fail, p.succeed).catchAllDefect(p.die).provide(env))
-            .unlessM(interrupted.isDone)
-        result         <- (q.offer((interruptedRef, effect)) *> p.await).onInterrupt {
-                            interrupted.succeed(()) <*
-                              // When the task is still in the queue before throttling, mark it as interrupted so we can filter it out
-                              interruptedRef.set(true) *>
-                              // When task is already executing, this means we have to wait for interruption to complete
-                              started.withPermit(ZIO.unit)
-                          }
+        action          = start.succeed(()) *> done.await
+        result         <-
+          ZManaged
+            .makeInterruptible_(q.offer((interruptedRef, action)))(interruptedRef.set(true) *> done.succeed(()))
+            .use_(start.await *> task)
       } yield result
     }
 }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -65,10 +65,9 @@ object RateLimiter extends RateLimiterPlatformSpecificObj {
         done           <- Promise.make[Nothing, Unit]
         interruptedRef <- Ref.make(false)
         action          = start.succeed(()) *> done.await
-        result         <-
-          ZManaged
-            .makeInterruptible_(q.offer((interruptedRef, action)))(interruptedRef.set(true) *> done.succeed(()))
-            .use_(start.await *> task)
+        result         <- ZManaged
+                            .makeInterruptible_(q.offer((interruptedRef, action)))(interruptedRef.set(true) *> done.succeed(()))
+                            .use_(start.await *> task)
       } yield result
     }
 }


### PR DESCRIPTION
* Use the stream just for signalling execution start
* Do not require providing the environment, which is relatively expensive
* Simplify interruption and defect handling
* Do not provide env on every call