### PR TITLE
Fix CircuitBreaker race condition

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -35,7 +35,8 @@ import zio.stream.ZStream
  * TODO what to do if you want this kind of behavior, or should we make it an option?
  *
  * 2) Failure rate. When the fraction of failed calls in some sample period exceeds a threshold (between 0 and 1), the
- * circuit breaker is tripped.
+ * circuit breaker is tripped. The decision to trip the Circuit Breaker is made after every call (including successful
+ * ones!)
  */
 trait CircuitBreaker[-E] {
   self =>

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -149,6 +149,7 @@ object CircuitBreaker {
       resetRequests  <- ZQueue.bounded[Unit](1).toManaged_
       _              <- ZStream
                           .fromQueue(resetRequests)
+                          .bufferDropping(1)
                           .mapM { _ =>
                             for {
                               _ <- schedule.next(())            // TODO handle schedule completion?

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -150,7 +150,6 @@ object CircuitBreaker {
       resetRequests  <- ZQueue.bounded[Unit](1).toManaged_
       _              <- ZStream
                           .fromQueue(resetRequests)
-                          .bufferDropping(1)
                           .mapM { _ =>
                             for {
                               _ <- schedule.next(())            // TODO handle schedule completion?

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/TrippingStrategy.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/TrippingStrategy.scala
@@ -31,7 +31,7 @@ object TrippingStrategy {
       new TrippingStrategy {
         override def onSuccess: UIO[Unit]     = nrFailedCalls.set(0)
         override def onFailure: UIO[Unit]     = nrFailedCalls.update(_ + 1)
-        override def shouldTrip: UIO[Boolean] = nrFailedCalls.get.map(_ == maxFailures)
+        override def shouldTrip: UIO[Boolean] = nrFailedCalls.get.map(_ >= maxFailures)
         override def onReset: UIO[Unit]       = nrFailedCalls.set(0)
       }
     }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/TrippingStrategy.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/TrippingStrategy.scala
@@ -11,7 +11,16 @@ import zio._
  * Custom implementations are supported
  */
 trait TrippingStrategy {
+
+  /**
+   * Called for every successful or failed call
+   *
+   * @param callSuccessful
+   * @return
+   *   If the CircuitBreaker should trip because of too many failures
+   */
   def shouldTrip(callSuccessful: Boolean): UIO[Boolean]
+
   def onReset: UIO[Unit]
 }
 

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/TrippingStrategy.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/TrippingStrategy.scala
@@ -31,7 +31,7 @@ object TrippingStrategy {
           nrFailedCalls.set(0).as(false)
         else
           nrFailedCalls.modify { case nrFailures =>
-            (nrFailures >= maxFailures, nrFailures + 1)
+            (nrFailures + 1 == maxFailures, nrFailures + 1)
           }
         override def onReset: UIO[Unit]                                = nrFailedCalls.set(0)
       }

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
@@ -24,13 +24,20 @@ object CircuitBreakerSpec extends DefaultRunnableSpec {
       }
     },
     testM("fails fast after max nr failures calls") {
-      CircuitBreaker.withMaxFailures(10, Schedule.exponential(1.second)).use { cb =>
-        for {
-          _      <- ZIO.foreach_(1 to 10)(_ => cb(ZIO.fail(MyCallError)).either)
-          result <- cb(ZIO.fail(MyCallError)).either
-        } yield assert(result)(isLeft(equalTo(CircuitBreaker.CircuitBreakerOpen)))
-      }
-    },
+      CircuitBreaker
+        .withMaxFailures(100, Schedule.exponential(1.second), onStateChange = state => ZIO.debug(state))
+        .use { cb =>
+          for {
+            _      <-
+              ZIO.foreachPar_(1 to 105)(i =>
+                cb(ZIO.fail(MyCallError)).either.debug(s"${i}").tapCause(c => ZIO.debug(c))
+              )
+            _      <- ZIO.debug("Step 2")
+            result <- cb(ZIO.fail(MyCallError)).either
+            _      <- ZIO.debug("Step 3")
+          } yield assert(result)(isLeft(equalTo(CircuitBreaker.CircuitBreakerOpen)))
+        }
+    } @@ TestAspect.diagnose(20.seconds),
     testM("ignore failures that should not be considered a failure") {
       val isFailure: PartialFunction[Error, Boolean] = {
         case MyNotFatalError => false

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
@@ -129,5 +129,5 @@ object CircuitBreakerSpec extends DefaultRunnableSpec {
         } yield assert(s1)(equalTo(State.HalfOpen))
       }
     }
-  ) @@ nonFlaky(20)
+  ) @@ nonFlaky
 }


### PR DESCRIPTION
When executing parallel calls, the 'failure count' tripping strategy would sometimes not trip due to a race condition between updating the strategy's state and the decision to trip.

These steps are now atomic.
