### PR TITLE
#264 Fix fiber interrupted issue in Bulkhead

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Bulkhead.scala
@@ -88,8 +88,7 @@ object Bulkhead {
                                onStart.bracket_(onEnd, task)
                              }
                              .runDrain
-                             .fork
-                             .toManaged_
+                             .forkManaged
     } yield new Bulkhead {
       override def apply[R, E, A](task: ZIO[R, E, A]): ZIO[R, BulkheadError[E], A] =
         for {


### PR DESCRIPTION
`.fork.toManaged_` does not behave the same as `.forkManaged` (= `.toManaged_.fork`)