### PR TITLE
[#314] 'CircuitBreaker.isFailure' logic not being executed.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys.resolvers
 val mainScala        = "2.13.10"
 val scala3Version    = "3.2.2"
 val allScala         = Seq(mainScala, scala3Version)
-val zioVersion       = "2.0.2"
+val zioVersion       = "2.0.8"
 val zioConfigVersion = "3.0.1"
 
 val excludeInferAny        = { options: Seq[String] => options.filterNot(Set("-Xlint:infer-any")) }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -202,9 +202,9 @@ object CircuitBreaker {
                               } yield ()).uninterruptible
 
                             f.either.flatMap {
-                              case Left(e) if isFailure.isDefinedAt(e) => ZIO.fail(e)
-                              case Left(e)                             => ZIO.left(WrappedError(e))
-                              case Right(e)                            => ZIO.right(e)
+                              case Left(e) if isFailure.applyOrElse[E1, Boolean](e, _ => false) => ZIO.fail(e)
+                              case Left(e)                                                      => ZIO.left(WrappedError(e))
+                              case Right(e)                                                     => ZIO.right(e)
 
                             }
                               .tapBoth(_ => onComplete(callSuccessful = false), _ => onComplete(callSuccessful = true))


### PR DESCRIPTION
The current logic which checks `isFailure` in `CircuitBreakerImpl.apply`

```scala
case Left(e) if isFailure.isDefinedAt(e) => ZIO.fail(e)
```

isn`t accomplishing the desired result and in almost all cases will return `false`.  The reason is that `isDefinedAt` only checks if `e` is covered within the domain of the `PartialFunction`, however it does not execute the logic of the partial function.

instead `applyOrElse` should be used to perform both operations:

```scala
case Left(e) if isFailure.applyOrElse[E1, Boolean](e, _ => false) => ZIO.fail(e)
```

There is also a bug in the `CircuitBreakerSpec` that is preventing the test from failing (the `either` is in the wrong spot).

Housekeeping:
- ZIO updated to 2.0.8