### PR TITLE
Fix circuit-breacker's getting stuck in half open state

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -2,7 +2,6 @@ package nl.vroste.rezilience
 
 import nl.vroste.rezilience.CircuitBreaker.{ CircuitBreakerCallError, State, StateChange }
 import nl.vroste.rezilience.Policy.PolicyError
-import nl.vroste.rezilience.Util.onDurationExceeding
 import zio._
 import zio.metrics.{ Metric, MetricLabel }
 import zio.stream.ZStream
@@ -286,16 +285,11 @@ object CircuitBreaker {
                             for {
                               isFirstCall <- halfOpenSwitch.getAndUpdate(_ => false)
                               result      <- if (isFirstCall) {
-                                               tapZIOOnUserDefinedFailure(
-                                                 // Catch some defect and release the halfOpenSwitch, preventing it from getting stuck in HalfOpen
-                                                 f.tapDefect(_ => halfOpenSwitch.set(true)) @@
-                                                   // Detect long evaluation and release the halfOpenSwitch so that other f gets
-                                                   // a chance to change the CircuitBreaker state, preventing it from getting stuck in HalfOpen
-                                                   onDurationExceeding(10.minute)(_ => halfOpenSwitch.set(true))
-                                               )(
+                                               tapZIOOnUserDefinedFailure(f)(
                                                  onFailure = (strategy.shouldTrip(false) *> changeToOpen).uninterruptible,
                                                  onSuccess = (changeToClosed *> strategy.onReset).uninterruptible
-                                               ).mapError(WrappedError(_))
+                                               ).tapDefect(_ => (strategy.shouldTrip(false) *> changeToOpen).uninterruptible)
+                                                 .mapError(WrappedError(_))
                                              } else {
                                                ZIO.fail(CircuitBreakerOpen)
                                              }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Util.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Util.scala
@@ -1,8 +1,21 @@
 package nl.vroste.rezilience
 
+import zio._
+
 private object Util {
   final def nextPow2(n: Int): Int = {
     val nextPow = (Math.log(n.toDouble) / Math.log(2.0)).ceil.toInt
     Math.pow(2.0, nextPow.toDouble).toInt.max(2)
   }
+
+  def onDurationExceeding(duration: Duration)(
+    callback: Duration => UIO[Any]
+  ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      override def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        callback(duration)
+          .delay(duration)
+          .fork
+          .flatMap(fiber => zio.onExit(_ => fiber.interrupt))
+    }
 }

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Util.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Util.scala
@@ -1,21 +1,8 @@
 package nl.vroste.rezilience
 
-import zio._
-
 private object Util {
   final def nextPow2(n: Int): Int = {
     val nextPow = (Math.log(n.toDouble) / Math.log(2.0)).ceil.toInt
     Math.pow(2.0, nextPow.toDouble).toInt.max(2)
   }
-
-  def onDurationExceeding(duration: Duration)(
-    callback: Duration => UIO[Any]
-  ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
-    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
-      override def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-        callback(duration)
-          .delay(duration)
-          .fork
-          .flatMap(fiber => zio.onExit(_ => fiber.interrupt))
-    }
 }

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
@@ -89,46 +89,17 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         assert(s6)(equalTo(State.Closed))).tapErrorCause(result => ZIO.debug(result))
     },
     test("have not stuck in HalfOpen if some defect happens") {
-      (for {
-        cb  <- CircuitBreaker.withMaxFailures(1)
-        _   <- cb(ZIO.fail(MyCallError)).either
-        s1  <- cb.currentState // Open
-        _   <- TestClock.adjust(1.second)
-        s20 <- cb.currentState // HalfOpen
-        _   <- cb(ZIO.dieMessage("Boom")).catchAllDefect(_ => ZIO.unit)
-        s21 <- cb.currentState // Still HalfOpen but not stuck
-        e1  <- cb(ZIO.fail(MyCallError)).either
-        s3  <- cb.currentState // Open again
+      for {
+        cb <- CircuitBreaker.withMaxFailures(1)
+        _  <- cb(ZIO.fail(MyCallError)).either
+        s1 <- cb.currentState // Open
+        _  <- TestClock.adjust(1.second)
+        s2 <- cb.currentState // HalfOpen
+        _  <- cb(ZIO.dieMessage("Boom")).catchAllDefect(_ => ZIO.unit)
+        s3 <- cb.currentState // Back to Open
       } yield assert(s1)(equalTo(State.Open)) &&
-        assert(s20)(equalTo(State.HalfOpen)) &&
-        assert(s21)(equalTo(State.HalfOpen)) &&
-        assert(s3)(equalTo(State.Open)) &&
-        assert(e1)(isLeft(equalTo(WrappedError(MyCallError))))).tapErrorCause(result => ZIO.debug(result))
-    },
-    test("have not stuck in HalfOpen if evaluation takes a long long time") {
-      (for {
-        cb          <- CircuitBreaker.withMaxFailures(1)
-        _           <- cb(ZIO.fail(MyCallError)).either
-        s1          <- cb.currentState // Open
-        _           <- TestClock.adjust(1.second)
-        s21         <- cb.currentState // HalfOpen
-        logTimeEval <- cb(ZIO.sleep(660.second) *> ZIO.dieMessage("Boom!")).forkDaemon
-        _           <- TestClock.adjust(599.second)
-        s22         <- cb.currentState // Stuck in HalfOpen
-        e1          <- cb(ZIO.fail(MyCallError)).either
-        _           <- TestClock.adjust(601.second)
-        s23         <- cb.currentState // Still HalfOpen but not stuck
-        e2          <- cb(ZIO.fail(MyCallError)).either
-        s3          <- cb.currentState // Open again
-        _           <- TestClock.adjust(1.second)
-        _           <- logTimeEval.interrupt
-      } yield assert(s1)(equalTo(State.Open)) &&
-        assert(s21)(equalTo(State.HalfOpen)) &&
-        assert(s22)(equalTo(State.HalfOpen)) &&
-        assert(e1)(isLeft(equalTo(CircuitBreakerOpen))) &&
-        assert(s23)(equalTo(State.HalfOpen)) &&
-        assert(s3)(equalTo(State.Open)) &&
-        assert(e2)(isLeft(equalTo(WrappedError(MyCallError))))).tapErrorCause(result => ZIO.debug(result))
+        assert(s2)(equalTo(State.HalfOpen)) &&
+        assert(s3)(equalTo(State.Open))
     },
     test("reset the exponential timeout after a Closed-Open-HalfOpen-Closed") {
       for {


### PR DESCRIPTION
Hey! Thank you for the great job!

We use `CircuitBreaker`, but time to time we face with the issue when it gets stuck in `HalfOpen`. I've looked over the source code and found two probable causes. The first one is when the very first effect, which captured `halfOpenSwitch`, fails with  defect and second one if effect gets stuck by itself. In the first case the only good way is to release `halfOpenSwitch`. In the second case it isn't so obvious, and I'm not pretty sure what to do. The best way which I was able to think out is to release `halfOpenSwitch` after of some considerable time.

We still have no idea what happens in our particular case. We added some diagnostic stuff and are still waiting when issue arise again and then, it may be, we'll get some more information.