### PR TITLE
Initialize circuit breaker metrics

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -215,11 +215,11 @@ object CircuitBreaker {
      */
     val initializeMetrics: UIO[Unit] =
       withMetrics { case CircuitBreakerMetrics(state, nrStateChanges, callsSuccess, callsFailure, callsRejected) =>
-        state.modify(0.0) *>
-          nrStateChanges.modify(0L) *>
-          callsSuccess.modify(0L) *>
-          callsFailure.modify(0L) *>
-          callsRejected.modify(0L)
+        state.set(0.0) *>
+          nrStateChanges.update(0L) *>
+          callsSuccess.update(0L) *>
+          callsFailure.update(0L) *>
+          callsRejected.update(0L)
       }
 
     private def withMetrics(f: CircuitBreakerMetrics => UIO[Unit]): UIO[Unit] =

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -178,6 +178,7 @@ object CircuitBreaker {
                            halfOpenSwitch,
                            metricLabels
                          )
+      _               <- cb.initializeMetrics
       _               <- cb.resetProcess
       _               <- cb.trackStateChanges
     } yield cb
@@ -195,7 +196,7 @@ object CircuitBreaker {
 
     override val stateChanges: ZIO[Scope, Nothing, Dequeue[StateChange]] = stateChangesHub.subscribe
 
-    val metrics = labels.map { labels =>
+    private val metrics = labels.map { labels =>
       CircuitBreakerMetrics(
         state = Metric
           .gauge("rezilience_circuit_breaker_state")
@@ -208,6 +209,18 @@ object CircuitBreaker {
           .tagged(labels)
       )
     }
+
+    /**
+     * Initializes metrics with defaults and notifies listeners about changes in the meter registry
+     */
+    val initializeMetrics: UIO[Unit] =
+      withMetrics { case CircuitBreakerMetrics(state, nrStateChanges, callsSuccess, callsFailure, callsRejected) =>
+        state.modify(0.0) *>
+          nrStateChanges.modify(0L) *>
+          callsSuccess.modify(0L) *>
+          callsFailure.modify(0L) *>
+          callsRejected.modify(0L)
+      }
 
     private def withMetrics(f: CircuitBreakerMetrics => UIO[Unit]): UIO[Unit] =
       ZIO.fromOption(metrics).flatMap(f).ignore

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
@@ -2,7 +2,7 @@ package nl.vroste.rezilience
 
 import nl.vroste.rezilience.CircuitBreaker.{ CircuitBreakerOpen, State, WrappedError }
 import zio._
-import zio.metrics.{ Metric, MetricLabel }
+import zio.metrics.{ MetricKey, MetricLabel, MetricState }
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect.{ nonFlaky, withLiveRandom }
@@ -165,21 +165,42 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         assertTrue(error2.asInstanceOf[WrappedError[Error]].error == MyNotFatalError) &&
         assertTrue(nrCalls == 1)
     },
-    suite("metrics")(
+    suiteAll("metrics") {
+
+      val metricStateKey =
+        MetricKey.gauge("rezilience_circuit_breaker_state").tagged(_: Set[MetricLabel])
+
+      val metricStateChangesKey =
+        MetricKey.counter("rezilience_circuit_breaker_state_changes").tagged(_: Set[MetricLabel])
+
+      val metricSuccessKey =
+        MetricKey.counter("rezilience_circuit_breaker_calls_success").tagged(_: Set[MetricLabel])
+
+      val metricFailedKey =
+        MetricKey.counter("rezilience_circuit_breaker_calls_failure").tagged(_: Set[MetricLabel])
+
+      val metricRejectedKey =
+        MetricKey.counter("rezilience_circuit_breaker_calls_rejected").tagged(_: Set[MetricLabel])
+
       test("has suitable initial metric values") {
         for {
           labels             <- ZIO.randomWith(_.nextUUID).map(uuid => Set(MetricLabel("test_id", uuid.toString)))
           _                  <- CircuitBreaker
                                   .withMaxFailures(3, metricLabels = Some(labels))
-          metricState        <- Metric.gauge("rezilience_circuit_breaker_calls_state").tagged(labels).value
-          metricStateChanges <- Metric.counter("rezilience_circuit_breaker_calls_state_changes").tagged(labels).value
-          metricSuccess      <- Metric.counter("rezilience_circuit_breaker_calls_success").tagged(labels).value
-          metricFailed       <- Metric.counter("rezilience_circuit_breaker_calls_failure").tagged(labels).value
-          metricRejected     <- Metric.counter("rezilience_circuit_breaker_calls_rejected").tagged(labels).value
+          metricState        <- metricStateKey(labels).current[MetricState.Gauge]
+          metricStateChanges <- metricStateChangesKey(labels).current[MetricState.Counter]
+          metricSuccess      <- metricSuccessKey(labels).current[MetricState.Counter]
+          metricFailed       <- metricFailedKey(labels).current[MetricState.Counter]
+          metricRejected     <- metricRejectedKey(labels).current[MetricState.Counter]
         } yield assertTrue(
-          metricSuccess.count == 0 && metricFailed.count == 0 && metricState.value == 0.0 && metricStateChanges.count == 0 && metricRejected.count == 0
+          metricSuccess.get.count == 0 &&
+            metricFailed.get.count == 0 &&
+            metricState.get.value == 0.0 &&
+            metricStateChanges.get.count == 0 &&
+            metricRejected.get.count == 0
         )
-      },
+      }
+
       test("tracks successful and failed calls") {
         for {
           labels        <- ZIO.randomWith(_.nextUUID).map(uuid => Set(MetricLabel("test_id", uuid.toString)))
@@ -187,36 +208,49 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
                              .withMaxFailures(3, metricLabels = Some(labels))
           _             <- cb(ZIO.unit)
           _             <- cb(ZIO.fail("Failed")).either
-          metricSuccess <- Metric.counter("rezilience_circuit_breaker_calls_success").tagged(labels).value
-          metricFailed  <- Metric.counter("rezilience_circuit_breaker_calls_failure").tagged(labels).value
-        } yield assertTrue(metricSuccess.count == 1 && metricFailed.count == 1)
-      },
+          metricSuccess <- metricSuccessKey(labels).current[MetricState.Counter]
+          metricFailed  <- metricFailedKey(labels).current[MetricState.Counter]
+        } yield assertTrue(
+          metricSuccess.get.count == 1 &&
+            metricFailed.get.count == 1
+        )
+      }
+
       test("records state changes") {
         for {
           labels <- ZIO.randomWith(_.nextUUID).map(uuid => Set(MetricLabel("test_id", uuid.toString)))
           cb     <- CircuitBreaker
                       .withMaxFailures(10, Schedule.exponential(1.second), metricLabels = Some(labels))
 
-          metricStateChanges = Metric.counter("rezilience_circuit_breaker_state_changes").tagged(labels)
-          metricState        = Metric.gauge("rezilience_circuit_breaker_state").tagged(labels)
-
           _                  <- ZIO.foreachDiscard(1 to 10)(_ => cb(ZIO.fail(MyCallError)).either)
           _                  <- TestClock.adjust(0.second)
-          stateAfterFailures <- metricState.value
+          stateAfterFailures <- metricStateKey(labels).current[MetricState.Gauge]
           _                  <- TestClock.adjust(1.second)
-          stateAfterReset    <- metricState.value
+          stateAfterReset    <- metricStateKey(labels).current[MetricState.Gauge]
           _                  <- TestClock.adjust(1.second)
           _                  <- cb(ZIO.unit)
           _                  <- TestClock.adjust(1.second)
-          stateChanges       <- metricStateChanges.value
-          stateFinal         <- metricState.value
+          stateChanges       <- metricStateChangesKey(labels).current[MetricState.Counter]
+          stateFinal         <- metricStateKey(labels).current[MetricState.Gauge]
         } yield assertTrue(
-          stateChanges.count == 3 &&
-            stateAfterFailures.value == 2.0 &&
-            stateAfterReset.value == 1.0 &&
-            stateFinal.value == 0.0
+          stateChanges.get.count == 3 &&
+            stateAfterFailures.get.value == 2.0 &&
+            stateAfterReset.get.value == 1.0 &&
+            stateFinal.get.value == 0.0
         )
       }
-    ) @@ withLiveRandom
+
+    } @@ withLiveRandom
   ) @@ nonFlaky
+
+  implicit class MetricKeyOps[Type](val metricKey: MetricKey[Type]) extends AnyVal {
+    def current[Out <: MetricState[Type]]: Task[Option[Out]] =
+      ZIO.metrics.map {
+        _.metrics.collectFirst {
+          case metricPair if metricPair.metricKey == metricKey =>
+            metricPair.metricState.asInstanceOf[Out]
+        }
+      }
+  }
+
 }

--- a/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
+++ b/rezilience/shared/src/test/scala/nl/vroste/rezilience/CircuitBreakerSpec.scala
@@ -167,7 +167,7 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
     },
     suite("metrics")(
       test("has suitable initial metric values") {
-        import MetricsStuff._
+        import Metrics._
         for {
           labels             <- ZIO.randomWith(_.nextUUID).map(uuid => Set(MetricLabel("test_id", uuid.toString)))
           _                  <- CircuitBreaker
@@ -186,7 +186,7 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         )
       },
       test("tracks successful and failed calls") {
-        import MetricsStuff._
+        import Metrics._
         for {
           labels        <- ZIO.randomWith(_.nextUUID).map(uuid => Set(MetricLabel("test_id", uuid.toString)))
           cb            <- CircuitBreaker
@@ -201,7 +201,7 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         )
       },
       test("records state changes") {
-        import MetricsStuff._
+        import Metrics._
         for {
           labels <- ZIO.randomWith(_.nextUUID).map(uuid => Set(MetricLabel("test_id", uuid.toString)))
           cb     <- CircuitBreaker
@@ -227,7 +227,7 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
     ) @@ withLiveRandom
   ) @@ nonFlaky
 
-  object MetricsStuff {
+  object Metrics {
 
     val metricStateKey = MetricKey.gauge("rezilience_circuit_breaker_state").tagged(_: Set[MetricLabel])
 


### PR DESCRIPTION
Hi! Using your library. Thanks for the great work!

When running the `CircuitBreaker`, we noticed that after the service starts and before the state changes, the `state` and `nrStateChanges` metrics are not collected. This is not very good, since we do not understand what state the breaker is in and cannot distinguish this from the loss of metrics.

Please take a look at my request. In it, I added metrics initialization and corrected the test implementation, since the current one was not quite accurate - metrics initialization occurred inside the test and the `state` and `nrStateChanges` metrics had incorrect names.

Unfortunately, the new test implementation still does not check for notifying metric listeners. I could do this, but it seems that this will lead to excessive complexity of the tests.