### PR TITLE
Handle HalfOpen interrupt

### DIFF
--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/CircuitBreaker.scala
@@ -303,6 +303,7 @@ object CircuitBreaker {
                                                  onSuccess = (changeToClosed *> strategy.onReset).uninterruptible
                                                ).tapDefect(_ => (strategy.shouldTrip(false) *> changeToOpen).uninterruptible)
                                                  .mapError(WrappedError(_))
+                                                 .onInterrupt(halfOpenSwitch.set(true))
                                              } else {
                                                ZIO.fail(CircuitBreakerOpen)
                                              }


### PR DESCRIPTION
Right now the circuit breaker has the following problem: when the first call in HalfOpen is interrupted, the circuit breaker gets stuck in HalfOpen forever, thus preventing any calls to the external system, with the only solution being to restart the application.

The most immediate remedy seems to be allowing the next call after interruption through and choosing the next state based on its result instead, as in general the call being interrupted doesn't say anything about the state of the external system. Switching to Open on interrupt might unnecessarily increase the time to recovery if the external system is already available, and switching to Closed might overload the external system if it's still struggling.

A more thorough solution would include either a choice of what to do on interrupt or matching failures by cause instead of the error channel, but this fix should be enough to prevent the circuit breaker from being stuck. It definitely did the trick for our application.