### PR TITLE
Set source=scala3, silence scala3-migration warnings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version=3.11.5
-runner.dialect = scala213
+runner.dialect = scala213source3
 maxColumn = 120
 align.preset = most
 continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
+import org.typelevel.scalacoptions.ScalacOption
 import org.typelevel.scalacoptions.ScalacOptions
 
 import sbt.Keys.resolvers
@@ -10,12 +11,20 @@ val zioConfigVersion = "4.0.8"
 
 lazy val commonJvmSettings = Seq(
   crossScalaVersions := allScala,
-  tpolecatScalacOptions ~= { options => options.filterNot(Set(ScalacOptions.lintInferAny)) }
+  tpolecatScalacOptions ~= { options => options.filterNot(Set(ScalacOptions.lintInferAny)) },
+  tpolecatScalacOptions ++= Set(
+    ScalacOption("-Wconf", List("cat=scala3-migration:s"), _ => true),
+    ScalacOptions.source3
+  )
 )
 
 lazy val commonJsSettings = Seq(
   crossScalaVersions := allScala,
-  tpolecatScalacOptions ~= { options => options.filterNot(Set(ScalacOptions.lintInferAny)) }
+  tpolecatScalacOptions ~= { options => options.filterNot(Set(ScalacOptions.lintInferAny)) },
+  tpolecatScalacOptions ++= Set(
+    ScalacOption("-Wconf", List("cat=scala3-migration:s"), _ => true),
+    ScalacOptions.source3
+  )
 )
 
 inThisBuild(

--- a/rezilience-config/src/test/scala/nl/vroste/rezilience/config/GenerateConfigDocs.scala
+++ b/rezilience-config/src/test/scala/nl/vroste/rezilience/config/GenerateConfigDocs.scala
@@ -3,7 +3,7 @@ package nl.vroste.rezilience.config
 import zio.{ Scope, ZIO, ZIOAppArgs }
 
 object GenerateConfigDocs extends zio.ZIOAppDefault {
-  override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
+  override def run: ZIO[Any & ZIOAppArgs & Scope, Any, Any] =
     ZIO
       .debug(s"""
                 |# Circuit Breaker

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/Policy.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/Policy.scala
@@ -20,7 +20,7 @@ trait Policy[-E] { self =>
    * @tparam E2
    * @return
    */
-  def compose[E2 <: E](that: Policy[PolicyError[E2]]): Policy[E2] =
+  infix def compose[E2 <: E](that: Policy[PolicyError[E2]]): Policy[E2] =
     new Policy[E2] {
       override def apply[R, E1 <: E2, A](f: ZIO[R, E1, A]): ZIO[R, PolicyError[E1], A] =
         that(self(f)).mapError(flattenWrappedError)

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
@@ -58,9 +58,9 @@ object RateLimiter {
              ) // Power of two because it is a more efficient queue implementation
       _ <- ZStream
              .fromQueue(q, maxChunkSize = 1)
-             .filterZIO { case (interrupted, effect @ _) => interrupted.get.map(!_) }
+             .filterZIO { case (interrupted, _) => interrupted.get.map(!_) }
              .throttleShape(max.toLong, interval, max.toLong)(_.size.toLong)
-             .mapZIOParUnordered(Int.MaxValue) { case (interrupted @ _, effect) => effect }
+             .mapZIOParUnordered(Int.MaxValue) { case (_, effect) => effect }
              .runDrain
              .forkScoped
     } yield new RateLimiter {

--- a/rezilience/shared/src/main/scala/nl/vroste/rezilience/SwitchablePolicy.scala
+++ b/rezilience/shared/src/main/scala/nl/vroste/rezilience/SwitchablePolicy.scala
@@ -26,7 +26,7 @@ trait SwitchablePolicy[E] extends Policy[E] {
    *   previous policy. FinishInFlight = Wait for completion of in-flight calls with the old policy before accepting
    */
   def switch[R0, E0, E2 >: E](
-    newPolicy: ZIO[Scope with R0, E0, Policy[E2]],
+    newPolicy: ZIO[Scope & R0, E0, Policy[E2]],
     mode: Mode = Mode.Transition
   ): ZIO[R0, E0, UIO[Unit]]
 }
@@ -43,8 +43,8 @@ object SwitchablePolicy {
    * Creates a Policy that can be replaced safely at runtime
    */
   def make[R0, E0, E](
-    initial: ZIO[Scope with R0, E0, Policy[E]]
-  ): ZIO[Scope with R0, E0, SwitchablePolicy[E]] =
+    initial: ZIO[Scope & R0, E0, Policy[E]]
+  ): ZIO[Scope & R0, E0, SwitchablePolicy[E]] =
     for {
       scope         <- Scope.make
       policyState   <- makeInUsePolicyState[R0, E0, E](scope, initial, awaitReady = ZIO.unit)
@@ -72,7 +72,7 @@ object SwitchablePolicy {
         }
 
       override def switch[R1, E1, E2 >: E](
-        newPolicy: ZIO[Scope with R1, E1, Policy[E2]],
+        newPolicy: ZIO[Scope & R1, E1, Policy[E2]],
         mode: Mode
       ): ZIO[R1, E1, UIO[Unit]] =
         mode match {
@@ -86,7 +86,7 @@ object SwitchablePolicy {
   private def switchTransition[E, E0, R0](
     scope: Scope.Closeable,
     currentPolicy: TRef[PolicyState[E]],
-    newPolicy: ZIO[Scope with R0, E0, Policy[E]]
+    newPolicy: ZIO[Scope & R0, E0, Policy[E]]
   ): ZIO[R0, E0, ZIO[Any, Nothing, Unit]] =
     for {
       newPolicyState     <- makeInUsePolicyState[R0, E0, E](scope, newPolicy, awaitReady = ZIO.unit)
@@ -110,7 +110,7 @@ object SwitchablePolicy {
   private def switchFinishInFlight[E, E0, R0](
     scope: Scope.Closeable,
     currentPolicy: TRef[PolicyState[E]],
-    newPolicy: ZIO[Scope with R0, E0, Policy[E]]
+    newPolicy: ZIO[Scope & R0, E0, Policy[E]]
   ): ZIO[R0, E0, ZIO[Any, Nothing, Unit]] =
     for {
       markAsReady                   <- Promise.make[Nothing, Unit]
@@ -146,7 +146,7 @@ object SwitchablePolicy {
 
   private def makeInUsePolicyState[R0, E0, E](
     scope: Scope.Closeable,
-    newPolicy: ZIO[Scope with R0, E0, Policy[E]],
+    newPolicy: ZIO[Scope & R0, E0, Policy[E]],
     awaitReady: UIO[Unit]
   ): ZIO[R0, E0, PolicyState[E]] = for {
     shutdownComplete <- Promise.make[Nothing, Unit]


### PR DESCRIPTION
Tested locally by running `sbt 'tpolecatCiMode; ++ rezilienceJVM/Test/compile`; possibly fixes #462. ~~Also I have no idea what I'm doing~~